### PR TITLE
feat: Add robots.txt and sitemap.xml for SEO

### DIFF
--- a/app/robots.ts
+++ b/app/robots.ts
@@ -1,0 +1,16 @@
+import type { MetadataRoute } from 'next'
+
+export default function robots(): MetadataRoute.Robots {
+  const baseUrl = 'https://etymology.thepushkarp.com'
+
+  return {
+    rules: [
+      {
+        userAgent: '*',
+        allow: '/',
+        disallow: '/api/',
+      },
+    ],
+    sitemap: `${baseUrl}/sitemap.xml`,
+  }
+}

--- a/app/sitemap.ts
+++ b/app/sitemap.ts
@@ -1,0 +1,14 @@
+import type { MetadataRoute } from 'next'
+
+export default function sitemap(): MetadataRoute.Sitemap {
+  const baseUrl = 'https://etymology.thepushkarp.com'
+
+  return [
+    {
+      url: baseUrl,
+      lastModified: new Date(),
+      changeFrequency: 'weekly',
+      priority: 1,
+    },
+  ]
+}


### PR DESCRIPTION
## Summary
- Add `app/robots.ts` to generate `/robots.txt` allowing crawlers on main site while blocking `/api/` routes
- Add `app/sitemap.ts` to generate `/sitemap.xml` listing the homepage with weekly update frequency
- Both use Next.js MetadataRoute types for type-safe generation

## Test plan
- [ ] Run `yarn build` and verify `/robots.txt` and `/sitemap.xml` routes appear in output
- [ ] After deployment, verify https://etymology.thepushkarp.com/robots.txt returns expected content
- [ ] After deployment, verify https://etymology.thepushkarp.com/sitemap.xml returns expected content

🤖 Generated with [Claude Code](https://claude.com/claude-code)