### PR TITLE
feat: UI enhancements batch - POS tags, Related Words, Modern Slang sources

### DIFF
--- a/components/EtymologyCard.tsx
+++ b/components/EtymologyCard.tsx
@@ -74,6 +74,28 @@ export const EtymologyCard = memo(function EtymologyCard({
           >
             {result.definition}
           </p>
+
+          {/* POS Tags - after definition */}
+          {result.partsOfSpeech && result.partsOfSpeech.length > 0 && (
+            <div className="flex flex-wrap gap-2 mt-4">
+              {result.partsOfSpeech.map(({ pos, definition, pronunciation }, idx) => (
+                <div
+                  key={`${pos}-${idx}`}
+                  className="group inline-flex items-center gap-2 px-3 py-1.5 bg-cream-dark/50 border border-charcoal/10 rounded-full"
+                  title={definition}
+                >
+                  <span className="text-xs font-serif uppercase tracking-wider text-charcoal/60">
+                    {pos}
+                  </span>
+                  {pronunciation && pronunciation !== result.pronunciation && (
+                    <span className="text-xs font-serif italic text-charcoal/50">
+                      {pronunciation}
+                    </span>
+                  )}
+                </div>
+              ))}
+            </div>
+          )}
         </header>
 
         {/* Roots section */}

--- a/components/EtymologyCard.tsx
+++ b/components/EtymologyCard.tsx
@@ -143,6 +143,58 @@ export const EtymologyCard = memo(function EtymologyCard({
           </div>
         </section>
 
+        {/* Related Words / Suggestions - after lore section */}
+        {result.suggestions && (
+          <section className="mb-8">
+            <h2 className="font-serif text-sm uppercase text-charcoal-light tracking-widest mb-4">
+              Related Words
+            </h2>
+            <div className="space-y-4">
+              {result.suggestions.synonyms && result.suggestions.synonyms.length > 0 && (
+                <SuggestionRow
+                  label="Synonyms"
+                  words={result.suggestions.synonyms}
+                  onWordClick={onWordClick}
+                  color="emerald"
+                />
+              )}
+              {result.suggestions.antonyms && result.suggestions.antonyms.length > 0 && (
+                <SuggestionRow
+                  label="Antonyms"
+                  words={result.suggestions.antonyms}
+                  onWordClick={onWordClick}
+                  color="rose"
+                />
+              )}
+              {result.suggestions.homophones && result.suggestions.homophones.length > 0 && (
+                <SuggestionRow
+                  label="Homophones"
+                  words={result.suggestions.homophones}
+                  onWordClick={onWordClick}
+                  color="amber"
+                />
+              )}
+              {result.suggestions.easilyConfusedWith &&
+                result.suggestions.easilyConfusedWith.length > 0 && (
+                  <SuggestionRow
+                    label="Often Confused With"
+                    words={result.suggestions.easilyConfusedWith}
+                    onWordClick={onWordClick}
+                    color="blue"
+                  />
+                )}
+              {result.suggestions.seeAlso && result.suggestions.seeAlso.length > 0 && (
+                <SuggestionRow
+                  label="See Also"
+                  words={result.suggestions.seeAlso}
+                  onWordClick={onWordClick}
+                  color="purple"
+                />
+              )}
+            </div>
+          </section>
+        )}
+
         {/* Sources footer */}
         <footer
           className="
@@ -239,4 +291,45 @@ function SourceBadge({ source }: { source: SourceReference }) {
   }
 
   return <span className={baseClasses}>{sourceLabel}</span>
+}
+
+function SuggestionRow({
+  label,
+  words,
+  onWordClick,
+  color,
+}: {
+  label: string
+  words: string[]
+  onWordClick: (word: string) => void
+  color: 'emerald' | 'rose' | 'amber' | 'blue' | 'purple'
+}) {
+  const colorClasses = {
+    emerald: 'border-emerald-200 hover:bg-emerald-50 hover:border-emerald-300',
+    rose: 'border-rose-200 hover:bg-rose-50 hover:border-rose-300',
+    amber: 'border-amber-200 hover:bg-amber-50 hover:border-amber-300',
+    blue: 'border-blue-200 hover:bg-blue-50 hover:border-blue-300',
+    purple: 'border-purple-200 hover:bg-purple-50 hover:border-purple-300',
+  }
+
+  return (
+    <div className="flex flex-wrap items-center gap-2">
+      <span className="text-xs font-serif uppercase tracking-wider text-charcoal/40 w-32 shrink-0">
+        {label}
+      </span>
+      {words.map((word) => (
+        <button
+          key={word}
+          onClick={() => onWordClick(word)}
+          className={`
+            px-2.5 py-1 text-sm font-serif text-charcoal/80
+            border rounded-md transition-colors cursor-pointer
+            ${colorClasses[color]}
+          `}
+        >
+          {word}
+        </button>
+      ))}
+    </div>
+  )
 }

--- a/components/EtymologyCard.tsx
+++ b/components/EtymologyCard.tsx
@@ -143,6 +143,40 @@ export const EtymologyCard = memo(function EtymologyCard({
           </div>
         </section>
 
+        {/* Modern Usage - after lore, before sources */}
+        {result.modernUsage && result.modernUsage.hasSlangMeaning && (
+          <section className="mb-8">
+            <h2 className="font-serif text-sm uppercase text-charcoal-light tracking-widest mb-4">
+              Modern Usage
+            </h2>
+            <div className="relative pl-6 border-l-2 border-violet-200">
+              {result.modernUsage.slangDefinition && (
+                <p className="font-serif text-lg text-charcoal/80 leading-relaxed mb-3">
+                  {result.modernUsage.slangDefinition}
+                </p>
+              )}
+              {result.modernUsage.popularizedBy && (
+                <p className="text-sm text-charcoal/60 mb-2">
+                  <span className="font-medium">Popularized by:</span>{' '}
+                  {result.modernUsage.popularizedBy}
+                </p>
+              )}
+              {result.modernUsage.contexts && result.modernUsage.contexts.length > 0 && (
+                <div className="flex flex-wrap gap-2 mt-3">
+                  {result.modernUsage.contexts.map((ctx) => (
+                    <span
+                      key={ctx}
+                      className="px-2 py-0.5 text-xs font-serif bg-violet-50 text-violet-700 border border-violet-200 rounded-full"
+                    >
+                      {ctx}
+                    </span>
+                  ))}
+                </div>
+              )}
+            </div>
+          </section>
+        )}
+
         {/* Sources footer */}
         <footer
           className="

--- a/lib/research.ts
+++ b/lib/research.ts
@@ -6,6 +6,8 @@
 
 import { fetchEtymonline } from './etymonline'
 import { fetchWiktionary } from './wiktionary'
+import { fetchWikipedia } from './wikipedia'
+import { fetchUrbanDictionary } from './urbanDictionary'
 import { ResearchContext, RootResearchData, LLMConfig } from './types'
 import Anthropic from '@anthropic-ai/sdk'
 
@@ -174,19 +176,23 @@ export async function conductAgenticResearch(
   let totalFetches = 0
   const normalizedWord = word.toLowerCase().trim()
 
-  // Phase 1: Initial fetch for main word
+  // Phase 1: Initial fetch for main word (4 sources in parallel)
   console.log(`[Research] Phase 1: Fetching main word "${normalizedWord}"`)
-  const [etymonlineData, wiktionaryData] = await Promise.all([
+  const [etymonlineData, wiktionaryData, wikipediaData, urbanDictData] = await Promise.all([
     fetchEtymonline(normalizedWord),
     fetchWiktionary(normalizedWord),
+    fetchWikipedia(normalizedWord).catch(() => null),
+    fetchUrbanDictionary(normalizedWord).catch(() => null),
   ])
-  totalFetches += 2
+  totalFetches += 4
 
   const context: ResearchContext = {
     mainWord: {
       word: normalizedWord,
       etymonline: etymonlineData,
       wiktionary: wiktionaryData,
+      wikipedia: wikipediaData,
+      urbanDictionary: urbanDictData,
     },
     identifiedRoots: [],
     rootResearch: [],
@@ -261,6 +267,14 @@ export function buildResearchPrompt(context: ResearchContext): string {
   }
   if (context.mainWord.wiktionary) {
     sections.push(`\n--- Wiktionary ---\n${context.mainWord.wiktionary.text}`)
+  }
+  if (context.mainWord.wikipedia) {
+    sections.push(`\n--- Wikipedia ---\n${context.mainWord.wikipedia.text}`)
+  }
+  if (context.mainWord.urbanDictionary) {
+    sections.push(
+      `\n--- Urban Dictionary (Modern Usage) ---\n${context.mainWord.urbanDictionary.text}`
+    )
   }
 
   // Identified roots

--- a/lib/research.ts
+++ b/lib/research.ts
@@ -181,8 +181,14 @@ export async function conductAgenticResearch(
   const [etymonlineData, wiktionaryData, wikipediaData, urbanDictData] = await Promise.all([
     fetchEtymonline(normalizedWord),
     fetchWiktionary(normalizedWord),
-    fetchWikipedia(normalizedWord).catch(() => null),
-    fetchUrbanDictionary(normalizedWord).catch(() => null),
+    fetchWikipedia(normalizedWord).catch((err) => {
+      console.error(`[Research] Wikipedia fetch failed for "${normalizedWord}":`, err)
+      return null
+    }),
+    fetchUrbanDictionary(normalizedWord).catch((err) => {
+      console.error(`[Research] Urban Dictionary fetch failed for "${normalizedWord}":`, err)
+      return null
+    }),
   ])
   totalFetches += 4
 

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -217,6 +217,8 @@ export interface ResearchContext {
     word: string
     etymonline: SourceData | null
     wiktionary: SourceData | null
+    wikipedia?: SourceData | null
+    urbanDictionary?: SourceData | null
   }
   identifiedRoots: string[]
   rootResearch: RootResearchData[]

--- a/lib/urbanDictionary.ts
+++ b/lib/urbanDictionary.ts
@@ -2,6 +2,22 @@ import { SourceData } from './types'
 
 const URBAN_DICTIONARY_API = 'https://api.urbandictionary.com/v0/define'
 
+/**
+ * Urban Dictionary API response entry
+ */
+interface UrbanDictionaryEntry {
+  definition: string
+  permalink: string
+  thumbs_up: number
+  author: string
+  word: string
+  defid: number
+  current_vote: string
+  written_on: string
+  example: string
+  thumbs_down: number
+}
+
 const NSFW_WORDS = [
   'fuck',
   'shit',
@@ -32,19 +48,15 @@ export async function fetchUrbanDictionary(word: string): Promise<SourceData | n
     const data = await response.json()
 
     // Filter to clean definitions with decent votes
-    const filtered = (data.list || [])
-      .filter((d: { thumbs_up: number }) => d.thumbs_up > 100)
-      .filter(
-        (d: { definition: string; example: string }) =>
-          isClean(d.definition) && isClean(d.example || '')
-      )
+    const entries = (data.list || []) as UrbanDictionaryEntry[]
+    const filtered = entries
+      .filter((d) => d.thumbs_up > 100)
+      .filter((d) => isClean(d.definition) && isClean(d.example || ''))
       .slice(0, 2)
 
     if (filtered.length === 0) return null
 
-    const text = filtered
-      .map((d: { definition: string }) => d.definition.replace(/\[|\]/g, ''))
-      .join('\n\n')
+    const text = filtered.map((d) => d.definition.replace(/\[|\]/g, '')).join('\n\n')
 
     return {
       text,

--- a/lib/urbanDictionary.ts
+++ b/lib/urbanDictionary.ts
@@ -1,0 +1,56 @@
+import { SourceData } from './types'
+
+const URBAN_DICTIONARY_API = 'https://api.urbandictionary.com/v0/define'
+
+const NSFW_WORDS = [
+  'fuck',
+  'shit',
+  'cock',
+  'dick',
+  'pussy',
+  'cunt',
+  'ass',
+  'penis',
+  'vagina',
+  'anal',
+  'orgasm',
+  'ejaculate',
+  'masturbat',
+]
+
+function isClean(text: string): boolean {
+  const lower = text.toLowerCase()
+  return !NSFW_WORDS.some((word) => lower.includes(word))
+}
+
+export async function fetchUrbanDictionary(word: string): Promise<SourceData | null> {
+  try {
+    const response = await fetch(`${URBAN_DICTIONARY_API}?term=${encodeURIComponent(word)}`)
+
+    if (!response.ok) return null
+
+    const data = await response.json()
+
+    // Filter to clean definitions with decent votes
+    const filtered = (data.list || [])
+      .filter((d: { thumbs_up: number }) => d.thumbs_up > 100)
+      .filter(
+        (d: { definition: string; example: string }) =>
+          isClean(d.definition) && isClean(d.example || '')
+      )
+      .slice(0, 2)
+
+    if (filtered.length === 0) return null
+
+    const text = filtered
+      .map((d: { definition: string }) => d.definition.replace(/\[|\]/g, ''))
+      .join('\n\n')
+
+    return {
+      text,
+      url: `https://www.urbandictionary.com/define.php?term=${encodeURIComponent(word)}`,
+    }
+  } catch {
+    return null
+  }
+}

--- a/lib/urbanDictionary.ts
+++ b/lib/urbanDictionary.ts
@@ -20,7 +20,7 @@ const NSFW_WORDS = [
 
 function isClean(text: string): boolean {
   const lower = text.toLowerCase()
-  return !NSFW_WORDS.some((word) => lower.includes(word))
+  return !NSFW_WORDS.some((word) => new RegExp(`\\b${word}\\b`).test(lower))
 }
 
 export async function fetchUrbanDictionary(word: string): Promise<SourceData | null> {

--- a/lib/wikipedia.ts
+++ b/lib/wikipedia.ts
@@ -1,0 +1,26 @@
+import { SourceData } from './types'
+
+const WIKIPEDIA_REST_API = 'https://en.wikipedia.org/api/rest_v1/page/summary'
+
+export async function fetchWikipedia(word: string): Promise<SourceData | null> {
+  try {
+    const response = await fetch(`${WIKIPEDIA_REST_API}/${encodeURIComponent(word)}`, {
+      headers: { 'User-Agent': 'EtymologyExplorer/1.0' },
+    })
+
+    if (!response.ok) return null
+
+    const data = await response.json()
+
+    if (data.type === 'disambiguation' || !data.extract) {
+      return null
+    }
+
+    return {
+      text: data.extract,
+      url: data.content_urls?.desktop?.page || `https://en.wikipedia.org/wiki/${word}`,
+    }
+  } catch {
+    return null
+  }
+}


### PR DESCRIPTION
## Summary

This PR bundles three UI enhancement features that were developed in parallel:

### 1. Part of Speech (POS) Tags (#25)
- Displays POS badges (noun, verb, adjective, etc.) after the word definition
- Shows alternate pronunciations when they differ from the main word (e.g., "record" as noun vs verb)
- Tooltip reveals POS-specific definition on hover
- Styled as scholarly pill-shaped badges matching the design system

### 2. Related Words Section (#23)
- New section after "The Story" showing synonyms, antonyms, homophones, etc.
- Color-coded clickable chips for each category:
  - **Emerald**: Synonyms
  - **Rose**: Antonyms
  - **Amber**: Homophones
  - **Blue**: Often Confused With (e.g., affect/effect)
  - **Purple**: See Also
- Clicking any chip triggers a new word search

### 3. Modern Slang Sources (#6)
- **New sources**: Wikipedia REST API + Urban Dictionary API
- Urban Dictionary includes NSFW filtering (word blocklist + 100+ upvotes threshold)
- Research pipeline now fetches 4 sources in parallel (was 2)
- New "Modern Usage" section with violet theme showing:
  - Slang definition
  - "Popularized by" attribution
  - Context tags (e.g., "internet culture", "LGBTQ+ community")
- Graceful degradation if new sources fail

## Files Changed

| File | Purpose |
|------|---------|
| `lib/wikipedia.ts` | **NEW** - Wikipedia REST API fetcher |
| `lib/urbanDictionary.ts` | **NEW** - Urban Dictionary API with NSFW filter |
| `lib/types.ts` | Extended `ResearchContext` with wikipedia/urbanDictionary |
| `lib/research.ts` | Updated Phase 1 to fetch 4 sources in parallel |
| `components/EtymologyCard.tsx` | Added POS, Modern Usage, and Related Words sections |

## Test Plan

### Setup
```bash
yarn install
yarn dev
```

### 1. POS Tags (#25)
- [ ] Search **"record"** → Should show `[NOUN /ˈrekərd/]` and `[VERB /rɪˈkɔːrd/]` badges with different pronunciations
- [ ] Search **"run"** → Should show `[NOUN]` and `[VERB]` (same pronunciation, no duplication)
- [ ] Search **"cat"** → Should show single `[NOUN]` badge
- [ ] Hover over any POS badge → Should see POS-specific definition tooltip

### 2. Related Words (#23)
- [ ] Search **"affect"** → Should see "Often Confused With" showing "effect"
- [ ] Search **"their"** → Should see "Homophones" with "there", "they're"
- [ ] Click any related word chip → Should trigger new search for that word
- [ ] Check color coding matches: synonyms=emerald, antonyms=rose, homophones=amber, confused=blue, see-also=purple

### 3. Modern Slang (#6)
- [ ] Search **"slay"** → Should see "Modern Usage" section with LGBTQ+/drag culture context
- [ ] Search **"yeet"** → Should see contexts and "popularized by" attribution
- [ ] Search **"cat"** → Should NOT show Modern Usage section (hasSlangMeaning: false)
- [ ] Check console for research logs showing 4 parallel fetches in Phase 1

### 4. Regression Tests
- [ ] Pronunciation audio button still works
- [ ] Ancestry tree visualization renders correctly
- [ ] Source badges in footer still link correctly

## Screenshots

_To be added after local testing_

Closes #25, #23, #6