### PR TITLE
[codex] Fix history sync and pronunciation config

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -25,9 +25,10 @@ ETYMOLOGY_KV_REST_API_TOKEN=
 # ElevenLabs TTS (optional - for pronunciation audio)
 # ===========================================
 # Get API key at https://elevenlabs.io
-# Default voice ID is "Rachel" - change for different voice
+# Set ELEVENLABS_VOICE_ID to a voice available in your My Voices list.
+# Free-tier accounts cannot use Voice Library/community voices via the API.
 ELEVENLABS_API_KEY=
-ELEVENLABS_VOICE_ID=21m00Tcm4TlvDq8ikWAM
+ELEVENLABS_VOICE_ID=
 
 # ===========================================
 # Feature Flags (optional — all default to enabled/false)

--- a/README.md
+++ b/README.md
@@ -79,6 +79,9 @@ FORCE_CACHE_ONLY=false
 RATE_LIMIT_ENABLED=true
 ```
 
+`ELEVENLABS_VOICE_ID` must be a voice available to your account in `My Voices`.
+Free-tier accounts cannot use Voice Library/community voices through the API.
+
 See `.env.example` for full documentation.
 
 For local load testing, set `RATE_LIMIT_ENABLED=false` in `.env.local` and restart `bun dev`.

--- a/app/api/pronunciation/route.ts
+++ b/app/api/pronunciation/route.ts
@@ -1,5 +1,5 @@
 import { NextRequest, NextResponse } from 'next/server'
-import { generatePronunciation, isElevenLabsConfigured } from '@/lib/elevenlabs'
+import { ElevenLabsApiError, generatePronunciation, isElevenLabsConfigured } from '@/lib/elevenlabs'
 import { getCachedAudio, cacheAudio } from '@/lib/cache'
 import { isValidWord, canonicalizeWord } from '@/lib/validation'
 import { getCostMode } from '@/lib/costGuard'
@@ -36,7 +36,13 @@ export async function GET(request: NextRequest) {
 
   if (!isElevenLabsConfigured()) {
     return NextResponse.json(
-      { success: false, error: 'Pronunciation service not configured' },
+      {
+        success: false,
+        error:
+          'Pronunciation service not configured. Set ELEVENLABS_API_KEY and ' +
+          'ELEVENLABS_VOICE_ID to a voice available in your My Voices list. ' +
+          'Free-tier accounts cannot use Voice Library voices via the API.',
+      },
       { status: 503 }
     )
   }
@@ -109,6 +115,14 @@ export async function GET(request: NextRequest) {
     })
   } catch (error) {
     console.error('[Pronunciation] Generation failed:', safeError(error))
+
+    if (error instanceof ElevenLabsApiError) {
+      return NextResponse.json(
+        { success: false, error: safeError(error.message) },
+        { status: error.status }
+      )
+    }
+
     return NextResponse.json(
       { success: false, error: 'Failed to generate pronunciation' },
       { status: 500 }

--- a/components/SearchBar.tsx
+++ b/components/SearchBar.tsx
@@ -3,8 +3,7 @@
 import { useState, useCallback, useEffect, useMemo, useRef } from 'react'
 import { useSearchParams } from 'next/navigation'
 import { MagnifyingGlassIcon } from '@heroicons/react/24/outline'
-import { useLocalStorage } from '@/lib/hooks/useLocalStorage'
-import type { HistoryEntry } from '@/lib/types'
+import { useHistory } from '@/lib/hooks/useHistory'
 import { SearchSuggestions, getSuggestionItems } from '@/components/SearchSuggestions'
 
 interface SearchBarProps {
@@ -20,7 +19,7 @@ export function SearchBar({ onSearch, isLoading, initialValue = '', inputRef }: 
   const [isFocused, setIsFocused] = useState(false)
   const [showSuggestions, setShowSuggestions] = useState(false)
   const [selectedIndex, setSelectedIndex] = useState(-1)
-  const [historyEntries] = useLocalStorage<HistoryEntry[]>('etymology-history', [])
+  const { history: historyEntries } = useHistory()
   const blurTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null)
   const searchParams = useSearchParams()
 

--- a/lib/elevenlabs.ts
+++ b/lib/elevenlabs.ts
@@ -7,15 +7,45 @@ import { fetchWithTimeout } from './fetchUtils'
 import { CONFIG } from './config'
 
 const ELEVENLABS_API = 'https://api.elevenlabs.io/v1'
+const DEFAULT_OUTPUT_FORMAT = 'mp3_44100_128'
 
-// Default voice: Rachel (clear, articulate - good for dictionary pronunciation)
-const DEFAULT_VOICE_ID = '21m00Tcm4TlvDq8ikWAM'
+export class ElevenLabsApiError extends Error {
+  status: number
+
+  constructor(message: string, status: number) {
+    super(message)
+    this.name = 'ElevenLabsApiError'
+    this.status = status
+  }
+}
+
+async function readElevenLabsError(response: Response): Promise<string> {
+  const contentType = response.headers.get('content-type') ?? ''
+
+  if (contentType.includes('application/json')) {
+    const payload = (await response.json().catch(() => null)) as {
+      detail?: { message?: string }
+      message?: string
+      error?: string
+    } | null
+
+    return (
+      payload?.detail?.message ??
+      payload?.message ??
+      payload?.error ??
+      `ElevenLabs API error: ${response.status}`
+    )
+  }
+
+  const text = await response.text().catch(() => '')
+  return text || `ElevenLabs API error: ${response.status}`
+}
 
 /**
- * Check if ElevenLabs is configured (API key present)
+ * Check if ElevenLabs is configured (API key + voice ID present)
  */
 export function isElevenLabsConfigured(): boolean {
-  return !!process.env.ELEVENLABS_API_KEY
+  return !!process.env.ELEVENLABS_API_KEY && !!process.env.ELEVENLABS_VOICE_ID
 }
 
 /**
@@ -25,14 +55,18 @@ export function isElevenLabsConfigured(): boolean {
  * @throws Error if API call fails
  */
 export async function generatePronunciation(word: string): Promise<ArrayBuffer> {
-  const voiceId = process.env.ELEVENLABS_VOICE_ID || DEFAULT_VOICE_ID
+  const voiceId = process.env.ELEVENLABS_VOICE_ID
+  if (!voiceId) {
+    throw new Error('ELEVENLABS_VOICE_ID is required for pronunciation audio')
+  }
 
   const response = await fetchWithTimeout(
-    `${ELEVENLABS_API}/text-to-speech/${voiceId}`,
+    `${ELEVENLABS_API}/text-to-speech/${voiceId}?output_format=${DEFAULT_OUTPUT_FORMAT}`,
     {
       method: 'POST',
       headers: {
         'xi-api-key': process.env.ELEVENLABS_API_KEY!,
+        Accept: 'audio/mpeg',
         'Content-Type': 'application/json',
       },
       body: JSON.stringify({
@@ -48,8 +82,8 @@ export async function generatePronunciation(word: string): Promise<ArrayBuffer> 
   )
 
   if (!response.ok) {
-    const errorText = await response.text().catch(() => 'Unknown error')
-    throw new Error(`ElevenLabs API error: ${response.status} - ${errorText}`)
+    const errorText = await readElevenLabsError(response)
+    throw new ElevenLabsApiError(errorText, response.status)
   }
 
   return response.arrayBuffer()

--- a/lib/hooks/useHistory.ts
+++ b/lib/hooks/useHistory.ts
@@ -1,43 +1,129 @@
 'use client'
 
-import { useLocalStorage } from './useLocalStorage'
-import { HistoryEntry } from '../types'
-import { useCallback } from 'react'
+import { useCallback, useSyncExternalStore } from 'react'
+import { HistoryEntry } from '@/lib/types'
 
+const HISTORY_STORAGE_KEY = 'etymology-history'
 const MAX_HISTORY_SIZE = 50
+const EMPTY_HISTORY: HistoryEntry[] = []
+
+type HistoryListener = () => void
+
+const listeners = new Set<HistoryListener>()
+let historySnapshot: HistoryEntry[] = EMPTY_HISTORY
+let isInitialized = false
+let isStorageListenerAttached = false
+
+function canUseDOM(): boolean {
+  return typeof window !== 'undefined'
+}
+
+function parseHistory(raw: string | null): HistoryEntry[] {
+  if (!raw) return EMPTY_HISTORY
+
+  try {
+    const parsed = JSON.parse(raw) as unknown
+    if (!Array.isArray(parsed)) return EMPTY_HISTORY
+
+    return parsed.filter(
+      (entry): entry is HistoryEntry =>
+        typeof entry === 'object' &&
+        entry !== null &&
+        typeof (entry as HistoryEntry).word === 'string' &&
+        typeof (entry as HistoryEntry).timestamp === 'number'
+    )
+  } catch (error) {
+    console.error(`Error reading localStorage key "${HISTORY_STORAGE_KEY}":`, error)
+    return EMPTY_HISTORY
+  }
+}
+
+function readHistoryFromStorage(): HistoryEntry[] {
+  if (!canUseDOM()) return EMPTY_HISTORY
+  return parseHistory(window.localStorage.getItem(HISTORY_STORAGE_KEY))
+}
+
+function ensureHistorySnapshot(): HistoryEntry[] {
+  if (!isInitialized) {
+    historySnapshot = readHistoryFromStorage()
+    isInitialized = true
+  }
+
+  return historySnapshot
+}
+
+function emitHistoryChange(): void {
+  listeners.forEach((listener) => listener())
+}
+
+function writeHistory(nextHistory: HistoryEntry[]): void {
+  historySnapshot = nextHistory
+  isInitialized = true
+
+  if (canUseDOM()) {
+    try {
+      window.localStorage.setItem(HISTORY_STORAGE_KEY, JSON.stringify(nextHistory))
+    } catch (error) {
+      console.error(`Error setting localStorage key "${HISTORY_STORAGE_KEY}":`, error)
+    }
+  }
+
+  emitHistoryChange()
+}
+
+function handleStorage(event: StorageEvent): void {
+  if (event.key !== HISTORY_STORAGE_KEY) return
+
+  historySnapshot = readHistoryFromStorage()
+  isInitialized = true
+  emitHistoryChange()
+}
+
+function subscribe(listener: HistoryListener): () => void {
+  listeners.add(listener)
+
+  if (canUseDOM() && !isStorageListenerAttached) {
+    window.addEventListener('storage', handleStorage)
+    isStorageListenerAttached = true
+  }
+
+  return () => {
+    listeners.delete(listener)
+
+    if (canUseDOM() && listeners.size === 0 && isStorageListenerAttached) {
+      window.removeEventListener('storage', handleStorage)
+      isStorageListenerAttached = false
+    }
+  }
+}
+
+function getSnapshot(): HistoryEntry[] {
+  return ensureHistorySnapshot()
+}
 
 export function useHistory() {
-  const [history, setHistory] = useLocalStorage<HistoryEntry[]>('etymology-history', [])
+  const history = useSyncExternalStore(subscribe, getSnapshot, () => EMPTY_HISTORY)
 
-  const addToHistory = useCallback(
-    (word: string) => {
-      setHistory((prev) => {
-        // Remove if already exists (we'll add to front)
-        const filtered = prev.filter((entry) => entry.word !== word.toLowerCase())
+  const addToHistory = useCallback((word: string) => {
+    const normalizedWord = word.toLowerCase()
+    const nextHistory = [
+      { word: normalizedWord, timestamp: Date.now() },
+      ...ensureHistorySnapshot().filter((entry) => entry.word !== normalizedWord),
+    ].slice(0, MAX_HISTORY_SIZE)
 
-        // Add to front
-        const newEntry: HistoryEntry = {
-          word: word.toLowerCase(),
-          timestamp: Date.now(),
-        }
-
-        // Keep max size
-        return [newEntry, ...filtered].slice(0, MAX_HISTORY_SIZE)
-      })
-    },
-    [setHistory]
-  )
+    writeHistory(nextHistory)
+  }, [])
 
   const clearHistory = useCallback(() => {
-    setHistory([])
-  }, [setHistory])
+    writeHistory(EMPTY_HISTORY)
+  }, [])
 
-  const removeFromHistory = useCallback(
-    (word: string) => {
-      setHistory((prev) => prev.filter((entry) => entry.word !== word.toLowerCase()))
-    },
-    [setHistory]
-  )
+  const removeFromHistory = useCallback((word: string) => {
+    const normalizedWord = word.toLowerCase()
+    const nextHistory = ensureHistorySnapshot().filter((entry) => entry.word !== normalizedWord)
+
+    writeHistory(nextHistory)
+  }, [])
 
   return {
     history,

--- a/lib/hooks/useLocalStorage.ts
+++ b/lib/hooks/useLocalStorage.ts
@@ -7,24 +7,20 @@ export function useLocalStorage<T>(
   initialValue: T
 ): [T, (value: T | ((prev: T) => T)) => void, boolean] {
   const [storedValue, setStoredValue] = useState<T>(initialValue)
-  const [isHydrated, setIsHydrated] = useState(false)
 
-  // Load from localStorage on mount - intentional hydration pattern
   useEffect(() => {
     try {
       const item = window.localStorage.getItem(key)
       if (item) {
+        // Intentional post-mount hydration from localStorage.
         // eslint-disable-next-line react-hooks/set-state-in-effect
         setStoredValue(JSON.parse(item))
       }
     } catch (error) {
       console.error(`Error reading localStorage key "${key}":`, error)
     }
-
-    setIsHydrated(true)
   }, [key])
 
-  // Return a wrapped version of useState's setter
   const setValue = useCallback(
     (value: T | ((prev: T) => T)) => {
       try {
@@ -42,5 +38,5 @@ export function useLocalStorage<T>(
     [key]
   )
 
-  return [storedValue, setValue, isHydrated]
+  return [storedValue, setValue, true]
 }


### PR DESCRIPTION
This PR fixes two user-visible issues in the etymology search flow.

The first issue was that search history only appeared after a refresh. The underlying cause was that different parts of the client were reading the same localStorage key through isolated React state, so a completed search wrote the new history entry without updating sibling consumers in the same tab. The fix introduces a dedicated shared history store in the client hook, updates the search suggestions to read from that store, and returns the generic localStorage hook to a simple persistence helper.

The second issue was that the pronunciation button failed even when the ElevenLabs route was wired up correctly. The root cause was configuration and error handling: the app allowed a default voice fallback that is not safe for free-tier API usage, and the route collapsed upstream ElevenLabs failures into a generic error. The fix requires an explicit account-available voice ID, clarifies that requirement in docs, requests explicit MP3 output from ElevenLabs, and surfaces the upstream API message and status so failures are actionable.

Validation for this change included eslint on the touched code paths, TypeScript type-checking, a successful production build, a browser verification that history updates immediately after search results arrive, and live ElevenLabs API checks confirming the configured premade voice returns MP3 audio while the prior library-style voice returned a paid-plan error.
