### PR TITLE
fix: return SSE for streamed cache and error paths

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,8 @@ Try it out at [etymology.thepushkarp.com](https://etymology.thepushkarp.com)
 - **Search History**: Track your vocabulary exploration with a persistent sidebar
 - **Surprise Me**: Discover random words to expand your vocabulary
 - **Structured Outputs**: Guaranteed valid JSON responses using constrained decoding
-- **Streaming UI**: Optional `?stream=true` server-sent events for source progress and token streaming
+- **Streaming UI**: Optional `?stream=true` server-sent events for source progress,
+  token streaming, cached hits, and early error responses
 - **Smart Caching**: Redis-backed caching reduces costs and improves speed (30d etymology, 1yr audio)
 - **Rate Limiting**: Per-IP protection via Upstash Redis with automatic budget enforcement
 

--- a/app/api/etymology/route.ts
+++ b/app/api/etymology/route.ts
@@ -19,6 +19,7 @@ import { safeError } from '@/lib/errorUtils'
 import { getEnv } from '@/lib/env'
 import { CONFIG } from '@/lib/config'
 import { emitSecurityEvent } from '@/lib/telemetry'
+import { streamErrorResponse, streamResultResponse } from '@/lib/streamingResponse'
 
 function countConfidence(result: EtymologyResult, level: StageConfidence): number {
   const allStages = [
@@ -29,54 +30,66 @@ function countConfidence(result: EtymologyResult, level: StageConfidence): numbe
 }
 
 export async function GET(request: NextRequest) {
+  let shouldStream = false
+
   try {
     // Validate environment (lazy, cached after first call)
     try {
       getEnv()
     } catch {
-      return NextResponse.json<ApiResponse<null>>(
-        { success: false, error: 'Service configuration error' },
-        { status: 503 }
-      )
+      return shouldStream
+        ? streamErrorResponse('Service configuration error')
+        : NextResponse.json<ApiResponse<null>>(
+            { success: false, error: 'Service configuration error' },
+            { status: 503 }
+          )
     }
 
     // Feature flags
     if (!CONFIG.features.publicSearchEnabled || CONFIG.features.forceCacheOnly) {
-      return NextResponse.json<ApiResponse<null>>(
-        { success: false, error: 'Service temporarily unavailable' },
-        { status: 503 }
-      )
+      return shouldStream
+        ? streamErrorResponse('Service temporarily unavailable')
+        : NextResponse.json<ApiResponse<null>>(
+            { success: false, error: 'Service temporarily unavailable' },
+            { status: 503 }
+          )
     }
 
     const word = request.nextUrl.searchParams.get('word')
-    const shouldStream = request.nextUrl.searchParams.get('stream') === 'true'
+    shouldStream = request.nextUrl.searchParams.get('stream') === 'true'
 
     if (!word || typeof word !== 'string') {
-      return NextResponse.json<ApiResponse<null>>(
-        { success: false, error: 'Word is required' },
-        { status: 400 }
-      )
+      return shouldStream
+        ? streamErrorResponse('Word is required')
+        : NextResponse.json<ApiResponse<null>>(
+            { success: false, error: 'Word is required' },
+            { status: 400 }
+          )
     }
 
     const normalizedWord = canonicalizeWord(word)
 
     if (!normalizedWord) {
-      return NextResponse.json<ApiResponse<null>>(
-        { success: false, error: getQuirkyMessage('empty') },
-        { status: 400 }
-      )
+      return shouldStream
+        ? streamErrorResponse(getQuirkyMessage('empty'))
+        : NextResponse.json<ApiResponse<null>>(
+            { success: false, error: getQuirkyMessage('empty') },
+            { status: 400 }
+          )
     }
 
     if (!isValidWord(normalizedWord)) {
-      return NextResponse.json<ApiResponse<null>>(
-        { success: false, error: getQuirkyMessage('nonsense') },
-        { status: 400 }
-      )
+      return shouldStream
+        ? streamErrorResponse(getQuirkyMessage('nonsense'))
+        : NextResponse.json<ApiResponse<null>>(
+            { success: false, error: getQuirkyMessage('nonsense') },
+            { status: 400 }
+          )
     }
 
     const costMode = await getCostMode()
 
-    // Always return JSON for cache hits (no point streaming cached data)
+    // Honor stream=true even for cached results so EventSource never receives JSON.
     const cached = await getCachedEtymology(normalizedWord)
     if (cached) {
       console.log(`[Etymology API] Cache hit for "${normalizedWord}"`)
@@ -85,15 +98,17 @@ export async function GET(request: NextRequest) {
         timestamp: Date.now(),
         detail: { word: normalizedWord },
       })
-      return NextResponse.json<ApiResponse<EtymologyResult> & { cached: boolean }>(
-        { success: true, data: cached, cached: true },
-        {
-          headers: {
-            'Cache-Control': 'public, s-maxage=86400, stale-while-revalidate=604800',
-            'X-Protection-Mode': costMode,
-          },
-        }
-      )
+      return shouldStream
+        ? streamResultResponse(cached, { 'X-Protection-Mode': costMode })
+        : NextResponse.json<ApiResponse<EtymologyResult> & { cached: boolean }>(
+            { success: true, data: cached, cached: true },
+            {
+              headers: {
+                'Cache-Control': 'public, s-maxage=86400, stale-while-revalidate=604800',
+                'X-Protection-Mode': costMode,
+              },
+            }
+          )
     }
 
     // Negative cache — skip source fetches for known gibberish
@@ -101,14 +116,16 @@ export async function GET(request: NextRequest) {
     if (isNegCached) {
       console.log(`[Etymology API] Negative cache hit for "${normalizedWord}"`)
       const suggestion = getRandomWord()
-      return NextResponse.json<ApiResponse<{ suggestion: string }>>(
-        {
-          success: false,
-          error: getQuirkyMessage('nonsense'),
-          data: { suggestion },
-        },
-        { status: 404 }
-      )
+      return shouldStream
+        ? streamErrorResponse(getQuirkyMessage('nonsense'))
+        : NextResponse.json<ApiResponse<{ suggestion: string }>>(
+            {
+              success: false,
+              error: getQuirkyMessage('nonsense'),
+              data: { suggestion },
+            },
+            { status: 404 }
+          )
     }
 
     // Reject uncached requests when monthly budget is exhausted
@@ -118,14 +135,20 @@ export async function GET(request: NextRequest) {
         timestamp: Date.now(),
         detail: { word: normalizedWord, mode: costMode, action: 'rejected' },
       })
-      return NextResponse.json<ApiResponse<null>>(
-        {
-          success: false,
-          error:
+      return shouldStream
+        ? streamErrorResponse(
             'Monthly budget reached. Cached words still work — try again next month for new ones.',
-        },
-        { status: 503, headers: { 'X-Protection-Mode': costMode } }
-      )
+            'budget',
+            { 'X-Protection-Mode': costMode }
+          )
+        : NextResponse.json<ApiResponse<null>>(
+            {
+              success: false,
+              error:
+                'Monthly budget reached. Cached words still work — try again next month for new ones.',
+            },
+            { status: 503, headers: { 'X-Protection-Mode': costMode } }
+          )
     }
 
     // Singleflight: prevent duplicate LLM calls for the same word
@@ -137,20 +160,24 @@ export async function GET(request: NextRequest) {
       console.log(`[Etymology API] Waiting for in-flight result for "${normalizedWord}"`)
       const result = await pollForResult(() => getCachedEtymology(normalizedWord))
       if (result) {
-        return NextResponse.json<ApiResponse<EtymologyResult> & { cached: boolean }>(
-          { success: true, data: result, cached: true },
-          {
-            headers: {
-              'Cache-Control': 'public, s-maxage=86400, stale-while-revalidate=604800',
-            },
-          }
-        )
+        return shouldStream
+          ? streamResultResponse(result)
+          : NextResponse.json<ApiResponse<EtymologyResult> & { cached: boolean }>(
+              { success: true, data: result, cached: true },
+              {
+                headers: {
+                  'Cache-Control': 'public, s-maxage=86400, stale-while-revalidate=604800',
+                },
+              }
+            )
       }
       // Timed out waiting — tell client to retry
-      return NextResponse.json<ApiResponse<null>>(
-        { success: false, error: 'Request in progress, please retry in a few seconds.' },
-        { status: 429, headers: { 'Retry-After': '2' } }
-      )
+      return shouldStream
+        ? streamErrorResponse('Request in progress, please retry in a few seconds.', 'rate_limit')
+        : NextResponse.json<ApiResponse<null>>(
+            { success: false, error: 'Request in progress, please retry in a few seconds.' },
+            { status: 429, headers: { 'Retry-After': '2' } }
+          )
     }
 
     try {
@@ -337,22 +364,28 @@ export async function GET(request: NextRequest) {
         error.message.includes('UNAUTHENTICATED') ||
         error.message.includes('PERMISSION_DENIED')
       ) {
-        return NextResponse.json<ApiResponse<null>>(
-          { success: false, error: 'Service temporarily unavailable' },
-          { status: 503 }
-        )
+        return shouldStream
+          ? streamErrorResponse('Service temporarily unavailable')
+          : NextResponse.json<ApiResponse<null>>(
+              { success: false, error: 'Service temporarily unavailable' },
+              { status: 503 }
+            )
       }
       if (error.message.includes('429')) {
-        return NextResponse.json<ApiResponse<null>>(
-          { success: false, error: 'Service is busy, please try again shortly' },
-          { status: 429 }
-        )
+        return shouldStream
+          ? streamErrorResponse('Service is busy, please try again shortly', 'rate_limit')
+          : NextResponse.json<ApiResponse<null>>(
+              { success: false, error: 'Service is busy, please try again shortly' },
+              { status: 429 }
+            )
       }
     }
 
-    return NextResponse.json<ApiResponse<null>>(
-      { success: false, error: 'An unexpected error occurred. Please try again.' },
-      { status: 500 }
-    )
+    return shouldStream
+      ? streamErrorResponse('An unexpected error occurred. Please try again.')
+      : NextResponse.json<ApiResponse<null>>(
+          { success: false, error: 'An unexpected error occurred. Please try again.' },
+          { status: 500 }
+        )
   }
 }

--- a/lib/streamingResponse.test.ts
+++ b/lib/streamingResponse.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, test } from 'bun:test'
+import { streamErrorResponse, streamResultResponse } from '@/lib/streamingResponse'
+import type { EtymologyResult } from '@/lib/types'
+
+const ETYMOLOGY_FIXTURE: EtymologyResult = {
+  word: 'love',
+  pronunciation: '/lʌv/',
+  definition: 'strong affection',
+  roots: [],
+  ancestryGraph: {
+    branches: [],
+  },
+  lore: 'A compact fixture for stream response tests.',
+  sources: [],
+}
+
+describe('streamingResponse', () => {
+  test('streamResultResponse emits a one-shot SSE result payload', async () => {
+    const response = streamResultResponse(ETYMOLOGY_FIXTURE, {
+      'X-Protection-Mode': 'normal',
+    })
+
+    expect(response.status).toBe(200)
+    expect(response.headers.get('content-type')).toBe('text/event-stream')
+    expect(response.headers.get('cache-control')).toBe('no-cache')
+    expect(response.headers.get('x-protection-mode')).toBe('normal')
+    expect(await response.text()).toBe(
+      `data: ${JSON.stringify({ type: 'result', data: ETYMOLOGY_FIXTURE })}\n\n`
+    )
+  })
+
+  test('streamErrorResponse keeps SSE-compatible 200 status for EventSource', async () => {
+    const response = streamErrorResponse(
+      'Monthly budget reached. Cached words still work.',
+      'budget'
+    )
+
+    expect(response.status).toBe(200)
+    expect(response.headers.get('content-type')).toBe('text/event-stream')
+    expect(await response.text()).toBe(
+      'data: {"type":"error","message":"Monthly budget reached. Cached words still work.","errorType":"budget"}\n\n'
+    )
+  })
+})

--- a/lib/streamingResponse.ts
+++ b/lib/streamingResponse.ts
@@ -1,0 +1,46 @@
+import type { EtymologyResult, StreamEvent } from '@/lib/types'
+
+const STREAM_HEADERS = {
+  'Content-Type': 'text/event-stream',
+  'Cache-Control': 'no-cache',
+  Connection: 'keep-alive',
+} as const
+
+type StreamErrorEvent = Extract<StreamEvent, { type: 'error' }>
+
+function buildHeaders(headers?: HeadersInit): Headers {
+  const merged = new Headers(STREAM_HEADERS)
+
+  if (!headers) {
+    return merged
+  }
+
+  const extraHeaders = new Headers(headers)
+  extraHeaders.forEach((value, key) => {
+    merged.set(key, value)
+  })
+
+  return merged
+}
+
+function serializeEvent(event: StreamEvent): string {
+  return `data: ${JSON.stringify(event)}\n\n`
+}
+
+export function streamResultResponse(result: EtymologyResult, headers?: HeadersInit): Response {
+  return new Response(serializeEvent({ type: 'result', data: result }), {
+    status: 200,
+    headers: buildHeaders(headers),
+  })
+}
+
+export function streamErrorResponse(
+  message: string,
+  errorType: StreamErrorEvent['errorType'] = 'unknown',
+  headers?: HeadersInit
+): Response {
+  return new Response(serializeEvent({ type: 'error', message, errorType }), {
+    status: 200,
+    headers: buildHeaders(headers),
+  })
+}


### PR DESCRIPTION
## Summary
When the UI searched with `stream=true`, the API only returned `text/event-stream` on the uncached happy path. Cached hits and early error exits still returned JSON, which caused `EventSource` to abort with MIME-type errors before the client fell back.

## What changed
- add a small streaming response helper for one-shot SSE `result` and `error` events
- return SSE for streamed cache hits, budget guards, validation failures, lock polling timeouts, and top-level request errors
- keep non-stream JSON behavior unchanged
- add a regression test for the SSE helper and update the README streaming contract note

## Verification
- `bun test lib/streamingResponse.test.ts`
- `bun run lint`
- `bun run build`
- local runtime verification with:
  - `curl -i -s 'http://localhost:3000/api/etymology?word=12345&stream=true'`
  - `curl -i -s 'http://localhost:3000/api/etymology?word=love&stream=true'`

## User-facing effect
Streamed searches no longer hit the browser-side `EventSource` MIME-type failure when the request resolves from cache or exits early with an error.