### PR TITLE
fix: hide Surprise me button while suggestions are open

### DIFF
--- a/components/ExploreExperience.tsx
+++ b/components/ExploreExperience.tsx
@@ -42,6 +42,7 @@ export function ExploreExperience() {
   const { state, events, partialResult, error, search, reset } = useStreamingEtymology()
   const currentWord = searchParams.get('q')?.toLowerCase() ?? null
   const [ngramData, setNgramData] = useState<NgramResult | null>(null)
+  const [suggestionsVisible, setSuggestionsVisible] = useState(false)
 
   useEffect(() => {
     const q = searchParams.get('q')
@@ -167,10 +168,16 @@ export function ExploreExperience() {
                   isLoading={state === 'loading'}
                   initialValue={searchParams.get('q') || ''}
                   inputRef={searchInputRef}
+                  onSuggestionsVisibilityChange={setSuggestionsVisible}
                 />
-                <div className="mt-5 flex justify-center">
-                  <SurpriseButton onWordSelected={navigateToWord} disabled={state === 'loading'} />
-                </div>
+                {!suggestionsVisible && (
+                  <div className="mt-5 flex justify-center">
+                    <SurpriseButton
+                      onWordSelected={navigateToWord}
+                      disabled={state === 'loading'}
+                    />
+                  </div>
+                )}
               </div>
             </div>
           </section>

--- a/components/SearchBar.tsx
+++ b/components/SearchBar.tsx
@@ -11,9 +11,16 @@ interface SearchBarProps {
   isLoading?: boolean
   initialValue?: string
   inputRef?: React.RefObject<HTMLInputElement | null>
+  onSuggestionsVisibilityChange?: (visible: boolean) => void
 }
 
-export function SearchBar({ onSearch, isLoading, initialValue = '', inputRef }: SearchBarProps) {
+export function SearchBar({
+  onSearch,
+  isLoading,
+  initialValue = '',
+  inputRef,
+  onSuggestionsVisibilityChange,
+}: SearchBarProps) {
   const [value, setValue] = useState(initialValue)
   const [inputValue, setInputValue] = useState(initialValue)
   const [isFocused, setIsFocused] = useState(false)
@@ -54,6 +61,10 @@ export function SearchBar({ onSearch, isLoading, initialValue = '', inputRef }: 
       setSelectedIndex(-1)
     }
   }, [selectedIndex, suggestionItems.length])
+
+  useEffect(() => {
+    onSuggestionsVisibilityChange?.(shouldShowSuggestions)
+  }, [shouldShowSuggestions, onSuggestionsVisibilityChange])
 
   useEffect(
     () => () => {


### PR DESCRIPTION
## Summary
- `SurpriseButton` sat directly beneath `SearchBar` and visually overlapped the absolutely-positioned suggestions dropdown once the user typed 2+ characters (see reported screenshot where "Surprise me" rendered between the Recent and Suggestions sections).
- `SearchBar` now exposes an optional `onSuggestionsVisibilityChange` callback driven by the existing `shouldShowSuggestions` flag.
- `ExploreExperience` tracks that flag and skips rendering the `SurpriseButton` block while suggestions are visible.

## Test plan
- [x] `bun run lint`
- [x] `bun run build`
- [x] `bun dev` — type `da`: dropdown shows Recent + Suggestions, Surprise me is hidden; blur/Escape: Surprise me returns.
- [x] Verified in dark mode.