### PR TITLE
[codex] Switch etymology LLM to OpenRouter

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,11 +1,11 @@
 # Etymology Explorer Environment Variables
 
 # ===========================================
-# OpenAI API Key (required)
+# OpenRouter API Key (required)
 # ===========================================
-# Server-side key for OpenAI Responses API access
-# Get one at https://platform.openai.com/api-keys
-OPENAI_API_KEY=
+# Server-side key for OpenRouter Responses API access
+# Get one at https://openrouter.ai/keys
+OPENROUTER_API_KEY=
 
 # ===========================================
 # Admin Secret (required for /api/admin/stats)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -10,9 +10,9 @@ Users search for a word, and the app:
 
 1. Fetches raw data from 6 sources in parallel (Etymonline, Wiktionary, Free Dictionary always; Wikipedia, Urban Dictionary, Incel Wiki as optional supplemental sources)
 2. Pre-parses etymological chains from source text (CPU-only)
-3. Uses OpenAI to extract root morphemes from the first-pass source bundle
+3. Uses OpenRouter to extract root morphemes from the first-pass source bundle
 4. Expands breadth with a bounded second pass over root pages and high-signal related pages from Etymonline and Wiktionary
-5. Sends the enriched research bundle to OpenAI's Responses API using `gpt-5.4-mini` for structured synthesis
+5. Sends the enriched research bundle to OpenRouter's Responses API using `openai/gpt-5.4-mini` for structured synthesis
 6. Post-processes LLM output to match ancestry stages to parsed evidence and assign programmatic confidence scores
 
 **Live**: https://etymology.thepushkarp.com
@@ -57,7 +57,7 @@ GET /api/etymology?word=X[&stream=true]
     │   └── Phase 5: Fetch bounded related-term pages (max 16 total fetches)
     ├── Typo check (lib/spellcheck.ts, Levenshtein distance vs GRE wordlist)
     ├── LLM synthesis (lib/llm.ts)
-    │   ├── Structured outputs via OpenAI Responses JSON schema mode
+    │   ├── Structured outputs via OpenRouter Responses JSON schema mode
     │   └── Post-processing: enrichAncestryGraph() matches stages to evidence, assigns confidence
     ├── Cache result in Redis
     └── Response: EtymologyResult with grounded ancestry stages
@@ -75,11 +75,11 @@ The app operates in **public mode** with server-side cost controls (added in PR 
 
 - **`lib/config.ts`** - Centralized configuration:
   - Per-IP rate caps: etymology 20/min + 200/day, pronunciation 20/min, general 60/min
-  - USD monthly limit: $10/month (`gpt-5.4-mini` pricing in `costTracking`)
+  - USD monthly limit: $10/month (`openai/gpt-5.4-mini` pricing in `costTracking`)
   - Timeouts: source fetches 5s, LLM 120s, TTS 8s
   - Rate limits, singleflight settings, feature flags
 
-- **`lib/env.ts`** - Zod-based env validation with lazy init (build-time safe). Validates OPENAI_API_KEY, ADMIN_SECRET, Redis credentials, ElevenLabs config.
+- **`lib/env.ts`** - Zod-based env validation with lazy init (build-time safe). Validates OPENROUTER_API_KEY, ADMIN_SECRET, Redis credentials, ElevenLabs config.
 
 - **`lib/costGuard.ts`** - Monthly USD budget enforcement via atomic Redis accumulation:
   - Normal mode (0-70% budget): allow uncached requests
@@ -131,7 +131,7 @@ Configured in `lib/config.ts` (consumed by `lib/research.ts`) to control API cos
 
 ### LLM Integration
 
-The app uses **OpenAI Responses structured JSON schema mode** for guaranteed valid JSON.
+The app uses **OpenRouter Responses structured JSON schema mode** for guaranteed valid JSON.
 
 **Schema split** (critical for maintainers):
 
@@ -146,7 +146,7 @@ LLM receives:
 3. JSON schema from `lib/schemas/llm-schema.ts`
 4. System prompt from `lib/prompts.ts`
 
-**Note**: OpenAI Responses calls use `text.format = { type: 'json_schema', ... }`.
+**Note**: OpenRouter Responses calls use `text.format = { type: 'json_schema', ... }`.
 
 ### State Management
 
@@ -163,7 +163,7 @@ LLM receives:
 
 - Search history (max 50 entries)
 - Theme preferences
-- (No API keys in public mode - server-side OPENAI_API_KEY used)
+- (No API keys in public mode - server-side OPENROUTER_API_KEY used)
 
 **Key hooks**:
 
@@ -235,7 +235,7 @@ All return `{ success: boolean, data?: T, error?: string }` wrapper.
 **Core Pipeline:**
 
 - `lib/research.ts` - Agentic research orchestrator (6-source parallel fetch)
-- `lib/llm.ts` - LLM client (OpenAI Responses API for `gpt-5.4-mini`)
+- `lib/llm.ts` - LLM client (OpenRouter Responses API for `openai/gpt-5.4-mini`)
 - `lib/prompts.ts` - System prompt for LLM synthesis
 
 **Schema & Types:**
@@ -257,4 +257,4 @@ All return `{ success: boolean, data?: T, error?: string }` wrapper.
 **Admin:**
 
 - `app/api/admin/stats/route.ts` - Budget monitoring endpoint
-- `.env.example` - Documents all env vars (OPENAI_API_KEY, ADMIN_SECRET, Redis, ElevenLabs)
+- `.env.example` - Documents all env vars (OPENROUTER_API_KEY, ADMIN_SECRET, Redis, ElevenLabs)

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ Try it out at [etymology.thepushkarp.com](https://etymology.thepushkarp.com)
 
 - Node.js 18+
 - For self-hosted deployment:
-  - [OpenAI](https://platform.openai.com/) API key (required)
+  - [OpenRouter](https://openrouter.ai/) API key (required)
   - [Upstash Redis](https://upstash.com/) (optional, for rate limiting and caching)
   - [ElevenLabs](https://elevenlabs.io/) (optional, for pronunciation audio)
 
@@ -54,10 +54,10 @@ Open [http://localhost:3000](http://localhost:3000) in your browser.
 
 ### Configuration
 
-The app runs in **public mode** using a server-side OpenAI API key and the
-`gpt-5.4-mini` model on the Responses API. All searches are rate-limited and
-cost-budgeted with a monthly spend cap. Set the `OPENAI_API_KEY` environment variable
-to enable it.
+The app runs in **public mode** using a server-side OpenRouter API key and the
+`openai/gpt-5.4-mini` model on OpenRouter's Responses API. All searches are
+rate-limited and cost-budgeted with a monthly spend cap. Set the
+`OPENROUTER_API_KEY` environment variable to enable it.
 
 ### Environment Configuration
 
@@ -65,7 +65,7 @@ For self-hosted deployments, create a `.env.local` file:
 
 ```bash
 # Required for public mode
-OPENAI_API_KEY=your_openai_key_here
+OPENROUTER_API_KEY=your_openrouter_key_here
 ADMIN_SECRET=your_admin_secret_here
 
 # Optional: Upstash Redis (rate limiting + caching)
@@ -94,8 +94,8 @@ For local load testing, set `RATE_LIMIT_ENABLED=false` in `.env.local` and resta
 
 - **Framework**: [Next.js 16.1](https://nextjs.org/) with App Router
 - **UI**: [React 19.2](https://react.dev/) + [Tailwind CSS v4](https://tailwindcss.com/)
-- **LLM**: [OpenAI Responses API](https://platform.openai.com/docs/api-reference/responses)
-  using `gpt-5.4-mini` with structured outputs
+- **LLM**: [OpenRouter Responses API](https://openrouter.ai/docs/api/api-reference/responses/create-responses)
+  using `openai/gpt-5.4-mini` with structured outputs
 - **Validation**: [Zod 4.x](https://zod.dev/) for schema validation
 - **Caching/Rate Limiting**: [@upstash/redis](https://upstash.com/) + [@upstash/ratelimit](https://github.com/upstash/ratelimit)
 - **Analytics**: [@vercel/analytics](https://vercel.com/analytics)
@@ -144,7 +144,7 @@ etymology-explorer/
 │   └── SurpriseButton.tsx  # Random word button
 ├── lib/
 │   ├── research.ts         # Agentic multi-source research pipeline
-│   ├── llm.ts              # OpenAI-backed LLM synthesis with structured outputs
+│   ├── llm.ts              # OpenRouter-backed LLM synthesis with structured outputs
 │   ├── etymologyParser.ts  # CPU-only source text parser
 │   ├── etymologyEnricher.ts # Post-LLM confidence enricher
 │   ├── etymonline.ts       # Etymonline HTML scraper
@@ -205,7 +205,7 @@ etymology-explorer/
    - **LLM Synthesis**: Aggregated research context sent to LLM with structured output schema
    - **Enricher** (CPU): Post-processes LLM output, assigns confidence scores (high/medium/low) based on source evidence match
 5. **Guaranteed JSON**: Using constrained decoding, the LLM produces valid JSON matching the exact schema
-6. **Budget Enforcement**: Cost guard tracks monthly spend and enforces protection modes (normal → protected_503 → cache_only → blocked) against a $10/month cap using `gpt-5.4-mini` pricing
+6. **Budget Enforcement**: Cost guard tracks monthly spend and enforces protection modes (normal → protected_503 → cache_only → blocked) against a $10/month cap using `openai/gpt-5.4-mini` pricing
 7. **Rich Display**: Etymology rendered with expandable roots, ancestry graph with confidence badges, POS tags, modern usage, related words, and source attribution (supplemental sources are only surfaced when significance checks pass)
 
 ### Architecture Diagram
@@ -234,10 +234,10 @@ etymology-explorer/
 │ Grounded Etymology Pipeline                                                  │
 │ 1) Fetch 6 sources in parallel                                               │
 │ 2) Parse "from X, from Y" chains (CPU-only)                                  │
-│ 3) OpenAI root extraction                                                    │
+│ 3) OpenRouter root extraction                                                │
 │ 4) Fetch root data                                                           │
 │ 5) Mine and fetch bounded related-term pages                                 │
-│ 6) OpenAI synthesis (stream tokens when stream=true)                         │
+│ 6) OpenRouter synthesis (stream tokens when stream=true)                     │
 │ 7) Enrich ancestry graph + confidence/evidence                               │
 │ 8) Cache result in Redis                                                     │
 └──────────────────────────────┬───────────────────────────────────────────────┘
@@ -286,5 +286,5 @@ MIT
 - Modern slang definitions from [Urban Dictionary](https://www.urbandictionary.com/)
 - Supplemental community slang context from [Incel Wiki](https://incels.wiki/)
 - Pronunciation audio from [ElevenLabs](https://elevenlabs.io/)
-- Powered by [OpenAI](https://platform.openai.com/) `gpt-5.4-mini`
+- Powered by [OpenRouter](https://openrouter.ai/) `openai/gpt-5.4-mini`
 - Rate limiting and caching by [Upstash](https://upstash.com/)

--- a/lib/apiError.test.ts
+++ b/lib/apiError.test.ts
@@ -2,9 +2,9 @@ import { describe, expect, test } from 'bun:test'
 import { classifyApiError } from '@/lib/apiError'
 
 describe('apiError', () => {
-  test('maps OpenAI timeouts to a retryable network-style message', () => {
+  test('maps OpenRouter timeouts to a retryable network-style message', () => {
     const classified = classifyApiError(
-      new Error('Streaming failed: OpenAI request timeout after 120000ms')
+      new Error('Streaming failed: OpenRouter request timeout after 120000ms')
     )
 
     expect(classified).toEqual({

--- a/lib/apiError.ts
+++ b/lib/apiError.ts
@@ -38,7 +38,7 @@ const MALFORMED_RESPONSE_PATTERNS = [
   'failed to parse streamed llm response',
   'could not parse a json object from model output',
   'schema validation failed',
-  'no text response from openai responses api',
+  'no text response from openrouter responses api',
   'streaming completed without output text',
 ]
 

--- a/lib/config.ts
+++ b/lib/config.ts
@@ -5,7 +5,7 @@
 
 export const CONFIG = {
   // LLM
-  model: 'gpt-5.4-mini',
+  model: 'openai/gpt-5.4-mini',
   synthesisMaxTokens: 9000,
   rootExtractionMaxTokens: 100,
 
@@ -42,7 +42,7 @@ export const CONFIG = {
   // Timeouts (milliseconds)
   timeouts: {
     source: 5_000,
-    llm: 120_000, // OpenAI Responses API
+    llm: 120_000, // OpenRouter Responses API
     tts: 8_000, // ElevenLabs
   },
 
@@ -55,7 +55,7 @@ export const CONFIG = {
 
   // USD-based cost tracking
   costTracking: {
-    pricingPerMillionTokens: { input: 0.25, output: 2.0 },
+    pricingPerMillionTokens: { input: 0.75, output: 4.5 },
     monthlyLimitUSD: 10.0,
     cacheOnlyAtPercent: 1.0, // serve only cached results at 100%
   },

--- a/lib/env.ts
+++ b/lib/env.ts
@@ -10,7 +10,7 @@ import { z } from 'zod'
 const emptyToUndefined = z.preprocess((val) => (val === '' ? undefined : val), z.string())
 
 const ServerEnvSchema = z.object({
-  OPENAI_API_KEY: z.string().min(1, 'OPENAI_API_KEY is required'),
+  OPENROUTER_API_KEY: z.string().min(1, 'OPENROUTER_API_KEY is required'),
   ADMIN_SECRET: emptyToUndefined.pipe(z.string().min(16)).optional(),
   ETYMOLOGY_KV_REST_API_URL: emptyToUndefined.pipe(z.string().url()).optional(),
   ETYMOLOGY_KV_REST_API_TOKEN: emptyToUndefined.pipe(z.string().min(1)).optional(),

--- a/lib/llm.ts
+++ b/lib/llm.ts
@@ -6,11 +6,11 @@ import { EtymologyResultSchema } from './schemas/etymology'
 import { CONFIG } from './config'
 import {
   buildSynthesisRequest,
-  createOpenAIResponse,
+  createOpenRouterResponse,
   extractOutputText,
   extractUsage,
-  streamOpenAIResponse,
-} from './openaiResponses'
+  streamOpenRouterResponse,
+} from './openrouterResponses'
 
 export interface SynthesisResult {
   result: EtymologyResult
@@ -68,7 +68,7 @@ function isAbortLikeError(error: unknown): boolean {
 }
 
 function timeoutErrorMessage(timeoutMs: number): string {
-  return `OpenAI request timeout after ${timeoutMs}ms`
+  return `OpenRouter request timeout after ${timeoutMs}ms`
 }
 
 function extractJsonObjectChunk(text: string): string | null {
@@ -276,7 +276,7 @@ async function callLlm(userPrompt: string): Promise<{
 
   let response
   try {
-    response = await createOpenAIResponse(request, CONFIG.timeouts.llm)
+    response = await createOpenRouterResponse(request, CONFIG.timeouts.llm)
   } catch (error) {
     if (isAbortLikeError(error)) {
       throw new Error(timeoutErrorMessage(CONFIG.timeouts.llm))
@@ -477,7 +477,7 @@ export async function streamSynthesis(
   let usage = { inputTokens: 0, outputTokens: 0 }
 
   try {
-    const response = await streamOpenAIResponse(
+    const response = await streamOpenRouterResponse(
       request,
       (token) => {
         fullText += token

--- a/lib/openrouterResponses.test.ts
+++ b/lib/openrouterResponses.test.ts
@@ -5,29 +5,40 @@ import {
   extractOutputText,
   reduceStreamEvent,
   extractUsage,
-} from '@/lib/openaiResponses'
+} from '@/lib/openrouterResponses'
 
-describe('openaiResponses', () => {
+describe('openrouterResponses', () => {
   test('buildSynthesisRequest uses low reasoning for faster visible synthesis output', () => {
     const request = buildSynthesisRequest('Analyze this word')
 
-    expect(request.model).toBe('gpt-5.4-mini')
+    expect(request.model).toBe('openai/gpt-5.4-mini')
     expect(request.reasoning).toEqual({ effort: 'low' })
     expect(request.max_output_tokens).toBe(9000)
     expect(request.text.format).toEqual({ type: 'text' })
     expect('temperature' in request).toBe(false)
   })
 
-  test('buildRootExtractionRequest keeps medium reasoning for root extraction stability', () => {
+  test('buildRootExtractionRequest disables reasoning for tiny root extraction output', () => {
     const request = buildRootExtractionRequest('Analyze roots')
 
-    expect(request.model).toBe('gpt-5.4-mini')
-    expect(request.reasoning).toEqual({ effort: 'medium' })
+    expect(request.model).toBe('openai/gpt-5.4-mini')
+    expect(request.reasoning).toEqual({ effort: 'none' })
     expect(request.max_output_tokens).toBe(100)
     expect(request.text.format).toMatchObject({
       type: 'json_schema',
-      name: 'root_array',
+      name: 'root_object',
       strict: true,
+      schema: {
+        type: 'object',
+        additionalProperties: false,
+        required: ['roots'],
+        properties: {
+          roots: {
+            type: 'array',
+            items: { type: 'string' },
+          },
+        },
+      },
     })
     expect('temperature' in request).toBe(false)
   })
@@ -69,7 +80,7 @@ describe('openaiResponses', () => {
         ],
       })
     ).toThrow(
-      'No text response from OpenAI Responses API (status=incomplete, incomplete=max_output_tokens, reasoningTokens=4096, maxOutputTokens=4096, output=message[refusal])'
+      'No text response from OpenRouter Responses API (status=incomplete, incomplete=max_output_tokens, reasoningTokens=4096, maxOutputTokens=4096, output=message[refusal])'
     )
   })
 
@@ -120,7 +131,7 @@ describe('openaiResponses', () => {
     })
   })
 
-  test('reduceStreamEvent captures finalized text when OpenAI sends done events', () => {
+  test('reduceStreamEvent captures finalized text when OpenRouter sends done events', () => {
     expect(
       reduceStreamEvent(
         {
@@ -195,5 +206,21 @@ describe('openaiResponses', () => {
       fullText: '',
       finalResponse: response,
     })
+  })
+
+  test('reduceStreamEvent throws OpenRouter top-level stream errors', () => {
+    expect(() =>
+      reduceStreamEvent(
+        {
+          fullText: 'partial',
+          finalResponse: null,
+        },
+        {
+          error: {
+            message: 'Provider disconnected unexpectedly',
+          },
+        }
+      )
+    ).toThrow('Provider disconnected unexpectedly')
   })
 })

--- a/lib/openrouterResponses.ts
+++ b/lib/openrouterResponses.ts
@@ -3,8 +3,15 @@ import { getEnv } from '@/lib/env'
 import { fetchWithTimeout } from '@/lib/fetchUtils'
 
 const ROOTS_JSON_SCHEMA = {
-  type: 'array',
-  items: { type: 'string' },
+  type: 'object',
+  additionalProperties: false,
+  required: ['roots'],
+  properties: {
+    roots: {
+      type: 'array',
+      items: { type: 'string' },
+    },
+  },
 } as const
 
 type TextFormat = {
@@ -20,7 +27,7 @@ type JsonSchemaFormat = {
 
 type ReasoningEffort = 'low' | 'medium' | 'high' | 'minimal' | 'none' | 'xhigh'
 
-export type OpenAIRequest = {
+export type OpenRouterRequest = {
   model: string
   input: string
   reasoning: { effort: ReasoningEffort }
@@ -29,17 +36,17 @@ export type OpenAIRequest = {
   instructions?: string
 }
 
-type OpenAIResponseContentItem = {
+type OpenRouterResponseContentItem = {
   type?: string
   text?: string
 }
 
-type OpenAIResponseOutputItem = {
+type OpenRouterResponseOutputItem = {
   type?: string
-  content?: OpenAIResponseContentItem[]
+  content?: OpenRouterResponseContentItem[]
 }
 
-type OpenAIUsage = {
+type OpenRouterUsage = {
   input_tokens?: number
   output_tokens?: number
   output_tokens_details?: {
@@ -47,23 +54,23 @@ type OpenAIUsage = {
   } | null
 }
 
-type OpenAIIncompleteDetails = {
+type OpenRouterIncompleteDetails = {
   reason?: string | null
 }
 
-export type OpenAIResponseLike = {
+export type OpenRouterResponseLike = {
   status?: string | null
   output_text?: string | null
-  output?: OpenAIResponseOutputItem[]
-  usage?: OpenAIUsage | null
-  incomplete_details?: OpenAIIncompleteDetails | null
+  output?: OpenRouterResponseOutputItem[]
+  usage?: OpenRouterUsage | null
+  incomplete_details?: OpenRouterIncompleteDetails | null
   max_output_tokens?: number | null
   error?: {
     message?: string
   } | null
 }
 
-type OpenAIStreamEvent = {
+type OpenRouterStreamEvent = {
   type?: string
   delta?: string
   text?: string
@@ -71,20 +78,20 @@ type OpenAIStreamEvent = {
     type?: string
     text?: string
   }
-  response?: OpenAIResponseLike
+  response?: OpenRouterResponseLike
   error?: {
     message?: string
   }
 }
 
-const OPENAI_RESPONSES_URL = 'https://api.openai.com/v1/responses'
+const OPENROUTER_RESPONSES_URL = 'https://openrouter.ai/api/v1/responses'
 
 function buildRequest(
   input: string,
   maxOutputTokens: number,
   format: JsonSchemaFormat | TextFormat,
   reasoningEffort: ReasoningEffort
-): OpenAIRequest {
+): OpenRouterRequest {
   return {
     model: CONFIG.model,
     input,
@@ -94,27 +101,27 @@ function buildRequest(
   }
 }
 
-export function buildSynthesisRequest(input: string): OpenAIRequest {
+export function buildSynthesisRequest(input: string): OpenRouterRequest {
   return buildRequest(input, CONFIG.synthesisMaxTokens, { type: 'text' }, 'low')
 }
 
-export function buildRootExtractionRequest(input: string): OpenAIRequest {
+export function buildRootExtractionRequest(input: string): OpenRouterRequest {
   return buildRequest(
     input,
     CONFIG.rootExtractionMaxTokens,
     {
       type: 'json_schema',
-      name: 'root_array',
+      name: 'root_object',
       strict: true,
       schema: ROOTS_JSON_SCHEMA,
     },
-    'medium'
+    'none'
   )
 }
 
 type StreamAccumulator = {
   fullText: string
-  finalResponse: OpenAIResponseLike | null
+  finalResponse: OpenRouterResponseLike | null
 }
 
 type StreamReduction = StreamAccumulator & {
@@ -156,7 +163,7 @@ function finalizeStreamText(state: StreamAccumulator, text: string): StreamReduc
 
 export function reduceStreamEvent(
   state: StreamAccumulator,
-  event: OpenAIStreamEvent
+  event: OpenRouterStreamEvent
 ): StreamReduction {
   if (
     (event.type === 'response.output_text.delta' || event.type === 'response.content_part.delta') &&
@@ -196,6 +203,10 @@ export function reduceStreamEvent(
     throw new Error(event.response?.error?.message ?? event.error?.message)
   }
 
+  if (event.error?.message) {
+    throw new Error(event.error.message)
+  }
+
   return {
     emittedText: '',
     fullText: state.fullText,
@@ -203,7 +214,7 @@ export function reduceStreamEvent(
   }
 }
 
-export function extractOutputText(response: OpenAIResponseLike): string {
+export function extractOutputText(response: OpenRouterResponseLike): string {
   if (response.output_text && response.output_text.trim().length > 0) {
     return response.output_text
   }
@@ -233,7 +244,7 @@ export function extractOutputText(response: OpenAIResponseLike): string {
   const maxOutputTokens = response.max_output_tokens ?? 'unknown'
 
   throw new Error(
-    `No text response from OpenAI Responses API ` +
+    `No text response from OpenRouter Responses API ` +
       `(status=${response.status ?? 'unknown'}, ` +
       `incomplete=${incompleteReason}, ` +
       `reasoningTokens=${reasoningTokens}, ` +
@@ -242,7 +253,7 @@ export function extractOutputText(response: OpenAIResponseLike): string {
   )
 }
 
-export function extractUsage(response: OpenAIResponseLike): {
+export function extractUsage(response: OpenRouterResponseLike): {
   inputTokens: number
   outputTokens: number
 } {
@@ -270,22 +281,22 @@ function extractErrorMessage(payload: unknown, status: number): string {
     }
   }
 
-  return `OpenAI request failed with status ${status}`
+  return `OpenRouter request failed with status ${status}`
 }
 
 function buildHeaders(): HeadersInit {
   return {
-    Authorization: `Bearer ${getEnv().OPENAI_API_KEY}`,
+    Authorization: `Bearer ${getEnv().OPENROUTER_API_KEY}`,
     'Content-Type': 'application/json',
   }
 }
 
-export async function createOpenAIResponse(
-  request: OpenAIRequest,
+export async function createOpenRouterResponse(
+  request: OpenRouterRequest,
   timeoutMs = CONFIG.timeouts.llm
-): Promise<OpenAIResponseLike> {
+): Promise<OpenRouterResponseLike> {
   const response = await fetchWithTimeout(
-    OPENAI_RESPONSES_URL,
+    OPENROUTER_RESPONSES_URL,
     {
       method: 'POST',
       headers: buildHeaders(),
@@ -294,7 +305,7 @@ export async function createOpenAIResponse(
     timeoutMs
   )
 
-  const payload = (await response.json()) as OpenAIResponseLike
+  const payload = (await response.json()) as OpenRouterResponseLike
   if (!response.ok) {
     throw new Error(extractErrorMessage(payload, response.status))
   }
@@ -319,13 +330,13 @@ function parseSseDataBlocks(chunk: string): string[] {
     .filter((block) => block.length > 0)
 }
 
-export async function streamOpenAIResponse(
-  request: OpenAIRequest,
+export async function streamOpenRouterResponse(
+  request: OpenRouterRequest,
   onText: (delta: string) => void,
   timeoutMs = CONFIG.timeouts.llm
-): Promise<OpenAIResponseLike> {
+): Promise<OpenRouterResponseLike> {
   const response = await fetchWithTimeout(
-    OPENAI_RESPONSES_URL,
+    OPENROUTER_RESPONSES_URL,
     {
       method: 'POST',
       headers: buildHeaders(),
@@ -345,14 +356,14 @@ export async function streamOpenAIResponse(
   }
 
   if (!response.body) {
-    throw new Error('OpenAI streaming response body was empty')
+    throw new Error('OpenRouter streaming response body was empty')
   }
 
   const reader = response.body.getReader()
   const decoder = new TextDecoder()
   let buffer = ''
   let fullText = ''
-  let finalResponse: OpenAIResponseLike | null = null
+  let finalResponse: OpenRouterResponseLike | null = null
 
   while (true) {
     const { done, value } = await reader.read()
@@ -368,7 +379,7 @@ export async function streamOpenAIResponse(
           continue
         }
 
-        const event = JSON.parse(data) as OpenAIStreamEvent
+        const event = JSON.parse(data) as OpenRouterStreamEvent
         const reduced = reduceStreamEvent(
           {
             fullText,
@@ -399,5 +410,5 @@ export async function streamOpenAIResponse(
     return { output_text: fullText, usage: null }
   }
 
-  throw new Error('OpenAI streaming completed without output text')
+  throw new Error('OpenRouter streaming completed without output text')
 }

--- a/lib/prompts.ts
+++ b/lib/prompts.ts
@@ -1,5 +1,5 @@
 /**
- * Prompt templates for OpenAI-backed GPT-5.4 mini etymology synthesis
+ * Prompt templates for OpenRouter-backed GPT-5.4 mini etymology synthesis
  */
 
 export const SYSTEM_PROMPT = `You are an etymology expert who makes word origins memorable and fascinating. You help vocabulary learners (especially GRE/TOEFL students) understand words deeply through their roots.

--- a/lib/research.ts
+++ b/lib/research.ts
@@ -16,9 +16,9 @@ import { CONFIG } from './config'
 import { safeError } from './errorUtils'
 import {
   buildRootExtractionRequest,
-  createOpenAIResponse,
+  createOpenRouterResponse,
   extractOutputText,
-} from './openaiResponses'
+} from './openrouterResponses'
 
 export async function extractRootsQuick(
   word: string,
@@ -42,7 +42,7 @@ Rules:
 Source data:
 ${sourceText}
 
-Return ONLY a JSON array of root strings (the actual morphemes, not full words).
+Return ONLY a JSON object with a "roots" array of root strings (the actual morphemes, not full words).
 Examples:
 - For "telephone": ["tele", "phone"]
 - For "autobiography": ["auto", "bio", "graph"]
@@ -50,14 +50,14 @@ Examples:
 - For "contradict": ["contra", "dict"]
 - For "cat": ["cat"]
 
-Return the JSON array only, no explanation:`
+Return the JSON object only, no explanation:`
 
   try {
     const request = buildRootExtractionRequest(prompt)
     request.instructions =
-      'Extract root morphemes only. Return a JSON array of lowercase strings with no commentary.'
+      'Extract root morphemes only. Return {"roots":["root"]} with lowercase strings and no commentary.'
 
-    const response = await createOpenAIResponse(request)
+    const response = await createOpenRouterResponse(request)
     return parseRootsArray(extractOutputText(response))
   } catch (error) {
     console.error('Root extraction error:', safeError(error))
@@ -70,6 +70,15 @@ Return the JSON array only, no explanation:`
  */
 function parseRootsArray(text: string): string[] {
   const normalizeRoots = (parsed: unknown): string[] => {
+    if (
+      parsed &&
+      typeof parsed === 'object' &&
+      !Array.isArray(parsed) &&
+      Array.isArray((parsed as { roots?: unknown }).roots)
+    ) {
+      return normalizeRoots((parsed as { roots: unknown[] }).roots)
+    }
+
     if (!Array.isArray(parsed)) return []
     return parsed
       .filter((item): item is string => typeof item === 'string')


### PR DESCRIPTION
## Summary

- route the Responses API provider wrapper through OpenRouter using `OPENROUTER_API_KEY`
- switch the configured model to `openai/gpt-5.4-mini` and update provider pricing/docs
- adjust root extraction to use an object-shaped structured output and no reasoning so the small extraction budget returns text

## Validation

- `bun test lib/openrouterResponses.test.ts lib/apiError.test.ts`
- `bun run lint`
- `bun run build`
- local smoke: `GET /api/etymology?word=florilegium` returned 200 and identified roots `flor, leg` through OpenRouter
