### PR TITLE
chore: add CI test/typecheck jobs and quality benchmark harness

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,29 @@
+# Dependency update automation.
+#
+# The bun ecosystem (not npm) is used so Dependabot updates bun.lock together
+# with package.json — npm-ecosystem updates rewrite only package.json, which
+# desyncs the lockfile and breaks `bun install --frozen-lockfile` in CI
+# (this is what happened with the next 16.2.6 bump in PR #63).
+version: 2
+updates:
+  - package-ecosystem: 'bun'
+    directory: '/'
+    schedule:
+      interval: 'weekly'
+    cooldown:
+      default-days: 7
+    groups:
+      dependencies:
+        patterns:
+          - '*'
+
+  - package-ecosystem: 'github-actions'
+    directory: '/'
+    schedule:
+      interval: 'weekly'
+    cooldown:
+      default-days: 7
+    groups:
+      actions:
+        patterns:
+          - '*'

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -20,6 +20,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
 
       - name: Setup Bun
         uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -26,7 +26,7 @@ jobs:
       - name: Setup Bun
         uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0
         with:
-          bun-version: latest
+          bun-version-file: package.json
 
       - name: Install dependencies
         run: bun install --frozen-lockfile

--- a/.github/workflows/lint-format.yml
+++ b/.github/workflows/lint-format.yml
@@ -20,6 +20,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
 
       - name: Setup Bun
         uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0

--- a/.github/workflows/lint-format.yml
+++ b/.github/workflows/lint-format.yml
@@ -26,7 +26,7 @@ jobs:
       - name: Setup Bun
         uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0
         with:
-          bun-version: latest
+          bun-version-file: package.json
 
       - name: Install dependencies
         run: bun install --frozen-lockfile

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -20,6 +20,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
 
       - name: Setup Bun
         uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0
@@ -38,6 +40,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
 
       - name: Setup Bun
         uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,51 @@
+name: Test and Typecheck
+
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+
+permissions:
+  contents: read
+
+concurrency:
+  group: test-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  test:
+    name: Test
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0
+        with:
+          bun-version: latest
+
+      - name: Install dependencies
+        run: bun install --frozen-lockfile
+
+      - name: Run tests
+        run: bun run test
+
+  typecheck:
+    name: Typecheck
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0
+        with:
+          bun-version: latest
+
+      - name: Install dependencies
+        run: bun install --frozen-lockfile
+
+      - name: Typecheck
+        run: bun run typecheck

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -26,7 +26,7 @@ jobs:
       - name: Setup Bun
         uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0
         with:
-          bun-version: latest
+          bun-version-file: package.json
 
       - name: Install dependencies
         run: bun install --frozen-lockfile
@@ -46,7 +46,7 @@ jobs:
       - name: Setup Bun
         uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0
         with:
-          bun-version: latest
+          bun-version-file: package.json
 
       - name: Install dependencies
         run: bun install --frozen-lockfile

--- a/.gitignore
+++ b/.gitignore
@@ -47,3 +47,6 @@ next-env.d.ts
 # docs
 docs/brainstorms/
 docs/plans/
+
+# benchmark results
+bench-results/

--- a/bun.lock
+++ b/bun.lock
@@ -11,7 +11,7 @@
         "@vercel/analytics": "^1.6.1",
         "@vercel/speed-insights": "^2.0.0",
         "lucide-react": "^0.563.0",
-        "next": "16.2.3",
+        "next": "16.2.6",
         "react": "19.2.3",
         "react-dom": "19.2.3",
         "zod": "^4.3.6",
@@ -164,25 +164,25 @@
 
     "@napi-rs/wasm-runtime": ["@napi-rs/wasm-runtime@0.2.12", "", { "dependencies": { "@emnapi/core": "^1.4.3", "@emnapi/runtime": "^1.4.3", "@tybys/wasm-util": "^0.10.0" } }, "sha512-ZVWUcfwY4E/yPitQJl481FjFo3K22D6qF0DuFH6Y/nbnE11GY5uguDxZMGXPQ8WQ0128MXQD7TnfHyK4oWoIJQ=="],
 
-    "@next/env": ["@next/env@16.2.3", "", {}, "sha512-ZWXyj4uNu4GCWQw9cjRxWlbD+33mcDszIo9iQxFnBX3Wmgq9ulaSJcl6VhuWx5pCWqqD+9W6Wfz7N0lM5lYPMA=="],
+    "@next/env": ["@next/env@16.2.6", "", {}, "sha512-gd8HoHN4ufj73WmR3JmVolrpJR47ILK6LouP5xElPglaVxir6e1a7VzvTvDWkOoPXT9rkkTzyCxBu4yeZfZwcw=="],
 
     "@next/eslint-plugin-next": ["@next/eslint-plugin-next@16.1.1", "", { "dependencies": { "fast-glob": "3.3.1" } }, "sha512-Ovb/6TuLKbE1UiPcg0p39Ke3puyTCIKN9hGbNItmpQsp+WX3qrjO3WaMVSi6JHr9X1NrmthqIguVHodMJbh/dw=="],
 
-    "@next/swc-darwin-arm64": ["@next/swc-darwin-arm64@16.2.3", "", { "os": "darwin", "cpu": "arm64" }, "sha512-u37KDKTKQ+OQLvY+z7SNXixwo4Q2/IAJFDzU1fYe66IbCE51aDSAzkNDkWmLN0yjTUh4BKBd+hb69jYn6qqqSg=="],
+    "@next/swc-darwin-arm64": ["@next/swc-darwin-arm64@16.2.6", "", { "os": "darwin", "cpu": "arm64" }, "sha512-ZJGkkcNfYgrrMkqOdZ7zoLa1TOy0qpcMfk/z4Mh/FKUz40gVO+HNQWqmLxf67Z5WB64DRp0dhEbyHfel+6sJUg=="],
 
-    "@next/swc-darwin-x64": ["@next/swc-darwin-x64@16.2.3", "", { "os": "darwin", "cpu": "x64" }, "sha512-gHjL/qy6Q6CG3176FWbAKyKh9IfntKZTB3RY/YOJdDFpHGsUDXVH38U4mMNpHVGXmeYW4wj22dMp1lTfmu/bTQ=="],
+    "@next/swc-darwin-x64": ["@next/swc-darwin-x64@16.2.6", "", { "os": "darwin", "cpu": "x64" }, "sha512-v/YLBHIY132Ced3puBJ7YJKw1lqsCrgcNo2aRJlCEyQrrCeRJlvGlnmxhPxNQI3KE3N1DN5r9TPNPvka3nq5RQ=="],
 
-    "@next/swc-linux-arm64-gnu": ["@next/swc-linux-arm64-gnu@16.2.3", "", { "os": "linux", "cpu": "arm64" }, "sha512-U6vtblPtU/P14Y/b/n9ZY0GOxbbIhTFuaFR7F4/uMBidCi2nSdaOFhA0Go81L61Zd6527+yvuX44T4ksnf8T+Q=="],
+    "@next/swc-linux-arm64-gnu": ["@next/swc-linux-arm64-gnu@16.2.6", "", { "os": "linux", "cpu": "arm64" }, "sha512-RPOvqlYBbcQjkz9VQQDZ2T2bARIjXZV1KFlt+V2Mr6SW/e4I9fcKsaA0hdyf2FHoTlsV2xnBd5Y912rP/1Ce6w=="],
 
-    "@next/swc-linux-arm64-musl": ["@next/swc-linux-arm64-musl@16.2.3", "", { "os": "linux", "cpu": "arm64" }, "sha512-/YV0LgjHUmfhQpn9bVoGc4x4nan64pkhWR5wyEV8yCOfwwrH630KpvRg86olQHTwHIn1z59uh6JwKvHq1h4QEw=="],
+    "@next/swc-linux-arm64-musl": ["@next/swc-linux-arm64-musl@16.2.6", "", { "os": "linux", "cpu": "arm64" }, "sha512-URUTu1+dMkxJsPFgm+OeEvq9wf5sujw0EvgYy80TDGHTSLTnIHeqb0Eu8A3sC95IRgjejQL+kC4mw+4yPxiAXA=="],
 
-    "@next/swc-linux-x64-gnu": ["@next/swc-linux-x64-gnu@16.2.3", "", { "os": "linux", "cpu": "x64" }, "sha512-/HiWEcp+WMZ7VajuiMEFGZ6cg0+aYZPqCJD3YJEfpVWQsKYSjXQG06vJP6F1rdA03COD9Fef4aODs3YxKx+RDQ=="],
+    "@next/swc-linux-x64-gnu": ["@next/swc-linux-x64-gnu@16.2.6", "", { "os": "linux", "cpu": "x64" }, "sha512-DOj182mPV8G3UkrayLoREM5YEYI+Dk5wv7Ox9xl1fFibAELEsFD0lDPfHIeILlutMMfdyhlzYPELG3peuKaurw=="],
 
-    "@next/swc-linux-x64-musl": ["@next/swc-linux-x64-musl@16.2.3", "", { "os": "linux", "cpu": "x64" }, "sha512-Kt44hGJfZSefebhk/7nIdivoDr3Ugp5+oNz9VvF3GUtfxutucUIHfIO0ZYO8QlOPDQloUVQn4NVC/9JvHRk9hw=="],
+    "@next/swc-linux-x64-musl": ["@next/swc-linux-x64-musl@16.2.6", "", { "os": "linux", "cpu": "x64" }, "sha512-HKQ5SP/V/ub73UvF7n/zeJlxk2kLmtL7Wzrg4WfmkjmNos5onJ2tKu7yZOPdL18A6Svfn3max29ym+ry7NkK4g=="],
 
-    "@next/swc-win32-arm64-msvc": ["@next/swc-win32-arm64-msvc@16.2.3", "", { "os": "win32", "cpu": "arm64" }, "sha512-O2NZ9ie3Tq6xj5Z5CSwBT3+aWAMW2PIZ4egUi9MaWLkwaehgtB7YZjPm+UpcNpKOme0IQuqDcor7BsW6QBiQBw=="],
+    "@next/swc-win32-arm64-msvc": ["@next/swc-win32-arm64-msvc@16.2.6", "", { "os": "win32", "cpu": "arm64" }, "sha512-LZXpTlPyS5v7HhSmnvsLGP3iIYgYOBnc8r8ArlT55sGHV89bR2HlDdBjWQ+PY6SJMmk8TuVGFuxalnP3k/0Dwg=="],
 
-    "@next/swc-win32-x64-msvc": ["@next/swc-win32-x64-msvc@16.2.3", "", { "os": "win32", "cpu": "x64" }, "sha512-Ibm29/GgB/ab5n7XKqlStkm54qqZE8v2FnijUPBgrd67FWrac45o/RsNlaOWjme/B5UqeWt/8KM4aWBwA1D2Kw=="],
+    "@next/swc-win32-x64-msvc": ["@next/swc-win32-x64-msvc@16.2.6", "", { "os": "win32", "cpu": "x64" }, "sha512-F0+4i0h9J6C4eE3EAPWsoCk7UW/dbzOjyzxY0qnDUOYFu6FFmdZ6l97/XdV3/Nz3VYyO7UWjyEJUXkGqcoXfMA=="],
 
     "@nodelib/fs.scandir": ["@nodelib/fs.scandir@2.1.5", "", { "dependencies": { "@nodelib/fs.stat": "2.0.5", "run-parallel": "^1.1.9" } }, "sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g=="],
 
@@ -714,7 +714,7 @@
 
     "natural-compare": ["natural-compare@1.4.0", "", {}, "sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw=="],
 
-    "next": ["next@16.2.3", "", { "dependencies": { "@next/env": "16.2.3", "@swc/helpers": "0.5.15", "baseline-browser-mapping": "^2.9.19", "caniuse-lite": "^1.0.30001579", "postcss": "8.4.31", "styled-jsx": "5.1.6" }, "optionalDependencies": { "@next/swc-darwin-arm64": "16.2.3", "@next/swc-darwin-x64": "16.2.3", "@next/swc-linux-arm64-gnu": "16.2.3", "@next/swc-linux-arm64-musl": "16.2.3", "@next/swc-linux-x64-gnu": "16.2.3", "@next/swc-linux-x64-musl": "16.2.3", "@next/swc-win32-arm64-msvc": "16.2.3", "@next/swc-win32-x64-msvc": "16.2.3", "sharp": "^0.34.5" }, "peerDependencies": { "@opentelemetry/api": "^1.1.0", "@playwright/test": "^1.51.1", "babel-plugin-react-compiler": "*", "react": "^18.2.0 || 19.0.0-rc-de68d2f4-20241204 || ^19.0.0", "react-dom": "^18.2.0 || 19.0.0-rc-de68d2f4-20241204 || ^19.0.0", "sass": "^1.3.0" }, "optionalPeers": ["@opentelemetry/api", "@playwright/test", "babel-plugin-react-compiler", "sass"], "bin": { "next": "dist/bin/next" } }, "sha512-9V3zV4oZFza3PVev5/poB9g0dEafVcgNyQ8eTRop8GvxZjV2G15FC5ARuG1eFD42QgeYkzJBJzHghNP8Ad9xtA=="],
+    "next": ["next@16.2.6", "", { "dependencies": { "@next/env": "16.2.6", "@swc/helpers": "0.5.15", "baseline-browser-mapping": "^2.9.19", "caniuse-lite": "^1.0.30001579", "postcss": "8.4.31", "styled-jsx": "5.1.6" }, "optionalDependencies": { "@next/swc-darwin-arm64": "16.2.6", "@next/swc-darwin-x64": "16.2.6", "@next/swc-linux-arm64-gnu": "16.2.6", "@next/swc-linux-arm64-musl": "16.2.6", "@next/swc-linux-x64-gnu": "16.2.6", "@next/swc-linux-x64-musl": "16.2.6", "@next/swc-win32-arm64-msvc": "16.2.6", "@next/swc-win32-x64-msvc": "16.2.6", "sharp": "^0.34.5" }, "peerDependencies": { "@opentelemetry/api": "^1.1.0", "@playwright/test": "^1.51.1", "babel-plugin-react-compiler": "*", "react": "^18.2.0 || 19.0.0-rc-de68d2f4-20241204 || ^19.0.0", "react-dom": "^18.2.0 || 19.0.0-rc-de68d2f4-20241204 || ^19.0.0", "sass": "^1.3.0" }, "optionalPeers": ["@opentelemetry/api", "@playwright/test", "babel-plugin-react-compiler", "sass"], "bin": { "next": "dist/bin/next" } }, "sha512-qOVgKJg1+At15NpeUP+eJgCHvTCgXsogweq87Ri/Ix7PkqQHg4sdaXmSFqKlgaIXE4kW0g25LE68W87UANlHtw=="],
 
     "node-releases": ["node-releases@2.0.27", "", {}, "sha512-nmh3lCkYZ3grZvqcCH+fjmQ7X+H0OeZgP40OierEaAptX4XofMh5kwNbWh7lBduUzCcV/8kZ+NDLCwm2iorIlA=="],
 

--- a/bun.lock
+++ b/bun.lock
@@ -18,6 +18,7 @@
       },
       "devDependencies": {
         "@tailwindcss/postcss": "^4.2.2",
+        "@types/bun": "^1.3.14",
         "@types/node": "^20.19.39",
         "@types/react": "^19.2.14",
         "@types/react-dom": "^19.2.3",
@@ -227,6 +228,8 @@
 
     "@tybys/wasm-util": ["@tybys/wasm-util@0.10.1", "", { "dependencies": { "tslib": "^2.4.0" } }, "sha512-9tTaPJLSiejZKx+Bmog4uSubteqTvFrVrURwkmHixBo0G4seD0zUxp98E1DzUBJxLQ3NPwXrGKDiVjwx/DpPsg=="],
 
+    "@types/bun": ["@types/bun@1.3.14", "", { "dependencies": { "bun-types": "1.3.14" } }, "sha512-h1hFqFVcvAvD9j9K7ZW7vd82aSA+rTdznZa+5bwvCwqSB1jmmfLcbIWhOLx1/+boy/xmjgCs/OMUL8hRJSmnPw=="],
+
     "@types/estree": ["@types/estree@1.0.8", "", {}, "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w=="],
 
     "@types/json-schema": ["@types/json-schema@7.0.15", "", {}, "sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA=="],
@@ -358,6 +361,8 @@
     "braces": ["braces@3.0.3", "", { "dependencies": { "fill-range": "^7.1.1" } }, "sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA=="],
 
     "browserslist": ["browserslist@4.28.1", "", { "dependencies": { "baseline-browser-mapping": "^2.9.0", "caniuse-lite": "^1.0.30001759", "electron-to-chromium": "^1.5.263", "node-releases": "^2.0.27", "update-browserslist-db": "^1.2.0" }, "bin": { "browserslist": "cli.js" } }, "sha512-ZC5Bd0LgJXgwGqUknZY/vkUQ04r8NXnJZ3yYi4vDmSiZmC/pdSN0NbNRPxZpbtO4uAfDUAFffO8IZoM3Gj8IkA=="],
+
+    "bun-types": ["bun-types@1.3.14", "", { "dependencies": { "@types/node": "*" } }, "sha512-4N0ig0fEomHt5R0KCFWjovxow98rIoRwKolrYdCcknNwMekCXRnWEUvgu5soYV8QXtVsrUD8B95MBOZGPvr6KQ=="],
 
     "call-bind": ["call-bind@1.0.8", "", { "dependencies": { "call-bind-apply-helpers": "^1.0.0", "es-define-property": "^1.0.0", "get-intrinsic": "^1.2.4", "set-function-length": "^1.2.2" } }, "sha512-oKlSFMcMwpUg2ednkhQ454wfWiU/ul3CkJe/PEHcTKuiX6RpbehUiFMXu13HalGZxfUwCQzZG747YXBn1im9ww=="],
 

--- a/lib/llm.ts
+++ b/lib/llm.ts
@@ -267,11 +267,14 @@ function sanitizeModernUsage(result: EtymologyResult, researchContext: ResearchC
   }
 }
 
-async function callLlm(userPrompt: string): Promise<{
+async function callLlm(
+  userPrompt: string,
+  model?: string
+): Promise<{
   text: string
   usage: { inputTokens: number; outputTokens: number }
 }> {
-  const request = buildSynthesisRequest(userPrompt)
+  const request = buildSynthesisRequest(userPrompt, model)
   request.instructions = SYSTEM_PROMPT
 
   let response
@@ -290,7 +293,10 @@ async function callLlm(userPrompt: string): Promise<{
   }
 }
 
-async function generateEtymologyResponse(userPrompt: string): Promise<{
+async function generateEtymologyResponse(
+  userPrompt: string,
+  model?: string
+): Promise<{
   result: EtymologyResult
   usage: { inputTokens: number; outputTokens: number }
 }> {
@@ -300,7 +306,7 @@ async function generateEtymologyResponse(userPrompt: string): Promise<{
 
   for (let attempt = 0; attempt < maxAttempts; attempt += 1) {
     try {
-      const { text, usage } = await callLlm(userPrompt)
+      const { text, usage } = await callLlm(userPrompt, model)
 
       try {
         const result = parseGeneratedJson(text)
@@ -451,12 +457,13 @@ function finalizeResult(
 }
 
 export async function synthesizeFromResearch(
-  researchContext: ResearchContext
+  researchContext: ResearchContext,
+  options?: { model?: string }
 ): Promise<SynthesisResult> {
   const researchData = buildResearchPrompt(researchContext)
   const userPrompt = buildRichUserPrompt(researchContext.mainWord.word, researchData)
 
-  const { result, usage } = await generateEtymologyResponse(userPrompt)
+  const { result, usage } = await generateEtymologyResponse(userPrompt, options?.model)
 
   return {
     result: finalizeResult(result, researchContext, 'standard'),

--- a/lib/openrouterResponses.ts
+++ b/lib/openrouterResponses.ts
@@ -90,10 +90,11 @@ function buildRequest(
   input: string,
   maxOutputTokens: number,
   format: JsonSchemaFormat | TextFormat,
-  reasoningEffort: ReasoningEffort
+  reasoningEffort: ReasoningEffort,
+  model?: string
 ): OpenRouterRequest {
   return {
-    model: CONFIG.model,
+    model: model ?? CONFIG.model,
     input,
     reasoning: { effort: reasoningEffort },
     max_output_tokens: maxOutputTokens,
@@ -101,8 +102,8 @@ function buildRequest(
   }
 }
 
-export function buildSynthesisRequest(input: string): OpenRouterRequest {
-  return buildRequest(input, CONFIG.synthesisMaxTokens, { type: 'text' }, 'low')
+export function buildSynthesisRequest(input: string, model?: string): OpenRouterRequest {
+  return buildRequest(input, CONFIG.synthesisMaxTokens, { type: 'text' }, 'low', model)
 }
 
 export function buildRootExtractionRequest(input: string): OpenRouterRequest {

--- a/lib/schemas/etymology.test.ts
+++ b/lib/schemas/etymology.test.ts
@@ -1,0 +1,142 @@
+import { describe, expect, test } from 'bun:test'
+import { EtymologyResultSchema } from '@/lib/schemas/etymology'
+
+/**
+ * Known-good fixture mirroring a real post-enrichment pipeline result:
+ * required core fields, a two-branch ancestry graph with merge point,
+ * and the optional enrichment fields (isReconstructed, confidence, evidence).
+ */
+const KNOWN_GOOD_RESULT = {
+  word: 'telephone',
+  pronunciation: '/ˈtɛlɪfoʊn/',
+  definition: 'A device that converts sound into electrical signals for transmission.',
+  roots: [
+    {
+      root: 'tele',
+      origin: 'Greek',
+      meaning: 'far, at a distance',
+      relatedWords: ['telegraph', 'television'],
+      ancestorRoots: ['*kʷel-'],
+      descendantWords: ['telepathy'],
+    },
+    {
+      root: 'phone',
+      origin: 'Greek',
+      meaning: 'sound, voice',
+      relatedWords: ['phonetic', 'symphony'],
+    },
+  ],
+  ancestryGraph: {
+    branches: [
+      {
+        root: 'tele',
+        stages: [
+          {
+            stage: 'Proto-Indo-European',
+            form: '*kʷel-',
+            note: 'to turn, revolve',
+            isReconstructed: true,
+            confidence: 'medium',
+            evidence: [{ source: 'wiktionary', snippet: 'from PIE *kʷel- "to turn"' }],
+          },
+          {
+            stage: 'Ancient Greek',
+            form: 'τῆλε',
+            note: 'afar, far off',
+            confidence: 'high',
+            evidence: [
+              { source: 'etymonline', snippet: 'from Greek tele- "far off"' },
+              { source: 'wiktionary', snippet: 'from Ancient Greek τῆλε (têle)' },
+            ],
+          },
+        ],
+      },
+      {
+        root: 'phone',
+        stages: [
+          {
+            stage: 'Ancient Greek',
+            form: 'φωνή',
+            note: 'sound, voice',
+            confidence: 'high',
+          },
+        ],
+      },
+    ],
+    convergencePoints: [
+      {
+        pieRoot: '*bʰeh₂-',
+        meaning: 'to speak',
+        branchIndices: [1],
+      },
+    ],
+    mergePoint: {
+      form: 'telephone',
+      note: 'coined in the 19th century from Greek elements',
+    },
+    postMerge: [
+      {
+        stage: 'Modern English',
+        form: 'telephone',
+        note: 'popularized after Bell patented his device in 1876',
+        confidence: 'high',
+      },
+    ],
+  },
+  lore: 'When Alexander Graham Bell needed a name for his talking machine, he reached back to Greek: tēle "far" and phōnē "voice" — literally a "far voice". The word had already been used for earlier acoustic devices, but Bell made it stick.',
+  sources: [
+    { name: 'etymonline', url: 'https://www.etymonline.com/word/telephone', word: 'telephone' },
+    { name: 'wiktionary', url: 'https://en.wiktionary.org/wiki/telephone', word: 'telephone' },
+  ],
+  partsOfSpeech: [
+    { pos: 'noun', definition: 'A telecommunications device.' },
+    { pos: 'verb', definition: 'To call someone using a telephone.' },
+  ],
+  suggestions: {
+    synonyms: ['phone'],
+    seeAlso: ['telegraph', 'phonograph'],
+  },
+  modernUsage: {
+    hasSlangMeaning: false,
+  },
+}
+
+describe('EtymologyResultSchema', () => {
+  test('parses a known-good etymology result', () => {
+    const parsed = EtymologyResultSchema.safeParse(KNOWN_GOOD_RESULT)
+
+    expect(parsed.success).toBe(true)
+    if (parsed.success) {
+      expect(parsed.data.word).toBe('telephone')
+      expect(parsed.data.roots).toHaveLength(2)
+      expect(parsed.data.ancestryGraph.branches[0]?.stages[0]?.isReconstructed).toBe(true)
+      expect(parsed.data.ancestryGraph.branches[0]?.stages[1]?.confidence).toBe('high')
+    }
+  })
+
+  test('preserves unknown fields for forward compatibility', () => {
+    const withExtras = { ...KNOWN_GOOD_RESULT, futureField: 'kept' }
+    const parsed = EtymologyResultSchema.safeParse(withExtras)
+
+    expect(parsed.success).toBe(true)
+    if (parsed.success) {
+      expect((parsed.data as Record<string, unknown>).futureField).toBe('kept')
+    }
+  })
+
+  test('rejects a result missing required core fields', () => {
+    const withoutLore: Record<string, unknown> = { ...KNOWN_GOOD_RESULT }
+    delete withoutLore.lore
+    expect(EtymologyResultSchema.safeParse(withoutLore).success).toBe(false)
+  })
+
+  test('rejects an invalid confidence value', () => {
+    const invalid = structuredClone(KNOWN_GOOD_RESULT) as Record<string, unknown>
+    const graph = invalid.ancestryGraph as {
+      branches: Array<{ stages: Array<{ confidence?: string }> }>
+    }
+    graph.branches[0]!.stages[0]!.confidence = 'certain'
+
+    expect(EtymologyResultSchema.safeParse(invalid).success).toBe(false)
+  })
+})

--- a/package.json
+++ b/package.json
@@ -2,6 +2,7 @@
   "name": "etymology-explorer",
   "version": "0.1.0",
   "private": true,
+  "packageManager": "bun@1.3.10",
   "scripts": {
     "dev": "next dev",
     "build": "next build",
@@ -10,6 +11,8 @@
     "lint:fix": "eslint . --fix",
     "format": "prettier --write .",
     "format:check": "prettier --check .",
+    "test": "bun test",
+    "typecheck": "tsc --noEmit",
     "prepare": "husky"
   },
   "lint-staged": {
@@ -35,6 +38,7 @@
   },
   "devDependencies": {
     "@tailwindcss/postcss": "^4.2.2",
+    "@types/bun": "^1.3.14",
     "@types/node": "^20.19.39",
     "@types/react": "^19.2.14",
     "@types/react-dom": "^19.2.3",

--- a/scripts/benchmark.ts
+++ b/scripts/benchmark.ts
@@ -27,11 +27,10 @@ import type { AncestryStage, EtymologyResult } from '@/lib/types'
 
 const RESULTS_DIR = join(process.cwd(), 'bench-results')
 
-const REQUIRED_ENV_VARS = [
-  'OPENROUTER_API_KEY',
-  'ETYMOLOGY_KV_REST_API_URL',
-  'ETYMOLOGY_KV_REST_API_TOKEN',
-] as const
+// The in-process research + synthesis path only needs the OpenRouter key today.
+// Redis (ETYMOLOGY_KV_*) is route-level infrastructure (cache/costGuard/singleflight)
+// and is not touched by this harness.
+const REQUIRED_ENV_VARS = ['OPENROUTER_API_KEY'] as const
 
 type Bucket = 'classical' | 'germanic' | 'neologism' | 'tricky'
 
@@ -74,7 +73,9 @@ interface WordBenchmark {
     synthesis: number
     total: number
   }
-  tokens: { input: number; output: number }
+  // Synthesis-call usage only: conductAgenticResearch does not expose the
+  // root-extraction LLM usage yet (wired up when fix/safety-hardening lands).
+  synthesisTokens: { input: number; output: number }
   rootCount: number
   ancestryStageCount: number
   confidence: ConfidenceDistribution
@@ -109,7 +110,8 @@ function assertRequiredEnv(): void {
   fail(
     `missing required environment variable(s): ${missing.join(', ')}.\n` +
       'Set them in .env.local (see .env.example for the full list) or export them ' +
-      'before running the benchmark.'
+      'before running the benchmark. Redis (ETYMOLOGY_KV_*) variables are NOT ' +
+      'required — the in-process pipeline does not use Redis.'
   )
 }
 
@@ -136,25 +138,6 @@ function countUngroundedReconstructed(stages: AncestryStage[]): number {
   return count
 }
 
-/**
- * Temporarily override the synthesis model. CONFIG's `as const` is type-level
- * only — the underlying object is mutable at runtime, and buildSynthesisRequest
- * reads CONFIG.model at call time. Root extraction (inside research) keeps the
- * default model; only the synthesis call is affected, matching the bake-off intent.
- */
-async function withModelOverride<T>(model: string | undefined, fn: () => Promise<T>): Promise<T> {
-  if (!model) return fn()
-
-  const mutableConfig = CONFIG as unknown as { model: string }
-  const originalModel = mutableConfig.model
-  mutableConfig.model = model
-  try {
-    return await fn()
-  } finally {
-    mutableConfig.model = originalModel
-  }
-}
-
 async function benchmarkWord(
   word: string,
   bucket: Bucket,
@@ -171,7 +154,7 @@ async function benchmarkWord(
     })
     const researchDone = performance.now()
 
-    const { result, usage } = await withModelOverride(model, () => synthesizeFromResearch(context))
+    const { result, usage } = await synthesizeFromResearch(context, { model })
     const synthesisDone = performance.now()
 
     const stages = collectStages(result.ancestryGraph)
@@ -191,7 +174,7 @@ async function benchmarkWord(
         synthesis: Math.round(synthesisDone - researchDone),
         total: Math.round(synthesisDone - startedAt),
       },
-      tokens: { input: usage.inputTokens, output: usage.outputTokens },
+      synthesisTokens: { input: usage.inputTokens, output: usage.outputTokens },
       rootCount: result.roots.length,
       ancestryStageCount: stages.length,
       confidence: distributeConfidence(stages),
@@ -216,7 +199,7 @@ async function benchmarkWord(
         synthesis: 0,
         total: Math.round(performance.now() - startedAt),
       },
-      tokens: { input: 0, output: 0 },
+      synthesisTokens: { input: 0, output: 0 },
       rootCount: 0,
       ancestryStageCount: 0,
       confidence: { high: 0, medium: 0, low: 0, unscored: 0 },
@@ -235,7 +218,7 @@ function formatWordLine(record: WordBenchmark): string {
   const seconds = (latencyMs.total / 1000).toFixed(1)
   return (
     `ok   ${record.word} [${record.bucket}] ${seconds}s | ` +
-    `${record.tokens.input} in / ${record.tokens.output} out tok | ` +
+    `${record.synthesisTokens.input} in / ${record.synthesisTokens.output} out tok | ` +
     `${record.rootCount} roots, ${record.ancestryStageCount} stages ` +
     `(${c.high}h/${c.medium}m/${c.low}l/${c.unscored}u) | ` +
     `${record.ungroundedReconstructedStages} ungrounded reconstructed`
@@ -285,8 +268,8 @@ async function runBenchmark(label: string, model: string | undefined): Promise<v
 interface Aggregates {
   okCount: number
   schemaValidCount: number
-  inputTokens: number
-  outputTokens: number
+  synthesisInputTokens: number
+  synthesisOutputTokens: number
   totalLatencyP50: number
   synthesisLatencyP50: number
   ungroundedReconstructed: number
@@ -315,8 +298,11 @@ function aggregate(summary: BenchmarkSummary): Aggregates {
   return {
     okCount: okRecords.length,
     schemaValidCount: summary.words.filter((record) => record.schemaValid).length,
-    inputTokens: okRecords.reduce((sum, record) => sum + record.tokens.input, 0),
-    outputTokens: okRecords.reduce((sum, record) => sum + record.tokens.output, 0),
+    synthesisInputTokens: okRecords.reduce((sum, record) => sum + record.synthesisTokens.input, 0),
+    synthesisOutputTokens: okRecords.reduce(
+      (sum, record) => sum + record.synthesisTokens.output,
+      0
+    ),
     totalLatencyP50: percentile(totals, 0.5),
     synthesisLatencyP50: percentile(synthesis, 0.5),
     ungroundedReconstructed: okRecords.reduce(
@@ -333,7 +319,7 @@ function formatAggregates(summary: BenchmarkSummary): string {
   const c = agg.confidence
   return [
     `Completed: ${agg.okCount}/${total} | schema-valid: ${agg.schemaValidCount}/${total}`,
-    `Tokens: ${agg.inputTokens} in / ${agg.outputTokens} out`,
+    `Tokens (synthesis only): ${agg.synthesisInputTokens} in / ${agg.synthesisOutputTokens} out`,
     `Latency p50: ${agg.totalLatencyP50}ms total, ${agg.synthesisLatencyP50}ms synthesis`,
     `Confidence: ${c.high} high / ${c.medium} medium / ${c.low} low / ${c.unscored} unscored`,
     `Ungrounded reconstructed stages: ${agg.ungroundedReconstructed}`,
@@ -346,7 +332,14 @@ function loadSummary(label: string): BenchmarkSummary {
   if (!existsSync(path)) {
     fail(`no summary found at bench-results/${label}/summary.json — run the benchmark first`)
   }
-  return JSON.parse(readFileSync(path, 'utf8')) as BenchmarkSummary
+  try {
+    return JSON.parse(readFileSync(path, 'utf8')) as BenchmarkSummary
+  } catch (error) {
+    return fail(
+      `could not parse bench-results/${label}/summary.json (${safeError(error)}). ` +
+        'The file may be corrupted — delete the run directory and re-run the benchmark.'
+    )
+  }
 }
 
 function compareRow(metric: string, a: number, b: number): string {
@@ -372,8 +365,12 @@ function compareLabels(labelA: string, labelB: string): void {
 
   console.log(compareRow('completed words', aggA.okCount, aggB.okCount))
   console.log(compareRow('schema-valid words', aggA.schemaValidCount, aggB.schemaValidCount))
-  console.log(compareRow('input tokens (total)', aggA.inputTokens, aggB.inputTokens))
-  console.log(compareRow('output tokens (total)', aggA.outputTokens, aggB.outputTokens))
+  console.log(
+    compareRow('input tokens (synthesis)', aggA.synthesisInputTokens, aggB.synthesisInputTokens)
+  )
+  console.log(
+    compareRow('output tokens (synthesis)', aggA.synthesisOutputTokens, aggB.synthesisOutputTokens)
+  )
   console.log(compareRow('latency p50 total (ms)', aggA.totalLatencyP50, aggB.totalLatencyP50))
   console.log(
     compareRow('latency p50 synthesis (ms)', aggA.synthesisLatencyP50, aggB.synthesisLatencyP50)

--- a/scripts/benchmark.ts
+++ b/scripts/benchmark.ts
@@ -1,0 +1,464 @@
+/**
+ * Quality benchmark harness for the etymology pipeline.
+ *
+ * Runs the full research + synthesis pipeline IN-PROCESS (no HTTP server) over a
+ * fixed 15-word set spanning 4 buckets, and records per-word quality/cost metrics
+ * so pipeline changes can be gated on before/after comparisons.
+ *
+ * Usage:
+ *   bun scripts/benchmark.ts --label <name> [--model <openrouter-slug>]
+ *   bun scripts/benchmark.ts --compare <labelA> <labelB>
+ *   bun scripts/benchmark.ts --help
+ *
+ * Each full run makes ~2 LLM calls per word (~$0.02/word, ~$0.30/run) plus
+ * external source fetches. Results are written to gitignored bench-results/<label>/.
+ */
+
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from 'node:fs'
+import { join } from 'node:path'
+import { parseArgs } from 'node:util'
+
+import { CONFIG } from '@/lib/config'
+import { safeError } from '@/lib/errorUtils'
+import { synthesizeFromResearch } from '@/lib/llm'
+import { conductAgenticResearch } from '@/lib/research'
+import { EtymologyResultSchema } from '@/lib/schemas/etymology'
+import type { AncestryStage, EtymologyResult } from '@/lib/types'
+
+const RESULTS_DIR = join(process.cwd(), 'bench-results')
+
+const REQUIRED_ENV_VARS = [
+  'OPENROUTER_API_KEY',
+  'ETYMOLOGY_KV_REST_API_URL',
+  'ETYMOLOGY_KV_REST_API_TOKEN',
+] as const
+
+type Bucket = 'classical' | 'germanic' | 'neologism' | 'tricky'
+
+const BENCHMARK_WORDS: ReadonlyArray<{ word: string; bucket: Bucket }> = [
+  { word: 'perfidious', bucket: 'classical' },
+  { word: 'telephone', bucket: 'classical' },
+  { word: 'autobiography', bucket: 'classical' },
+  { word: 'incredible', bucket: 'classical' },
+  { word: 'bread', bucket: 'germanic' },
+  { word: 'understand', bucket: 'germanic' },
+  { word: 'harvest', bucket: 'germanic' },
+  { word: 'word', bucket: 'germanic' },
+  { word: 'selfie', bucket: 'neologism' },
+  { word: 'doomscrolling', bucket: 'neologism' },
+  { word: 'rizz', bucket: 'neologism' },
+  { word: 'nice', bucket: 'tricky' },
+  { word: 'muscle', bucket: 'tricky' },
+  { word: 'quarantine', bucket: 'tricky' },
+  { word: 'sincere', bucket: 'tricky' },
+]
+
+interface ConfidenceDistribution {
+  high: number
+  medium: number
+  low: number
+  unscored: number
+}
+
+interface WordBenchmark {
+  word: string
+  bucket: Bucket
+  ok: boolean
+  error?: string
+  schemaValid: boolean
+  latencyMs: {
+    sourceFetch: number
+    rootExtraction: number
+    expansion: number
+    research: number
+    synthesis: number
+    total: number
+  }
+  tokens: { input: number; output: number }
+  rootCount: number
+  ancestryStageCount: number
+  confidence: ConfidenceDistribution
+  ungroundedReconstructedStages: number
+  lore: string
+}
+
+interface BenchmarkSummary {
+  label: string
+  model: string
+  startedAt: string
+  durationMs: number
+  words: WordBenchmark[]
+}
+
+function fail(message: string): never {
+  console.error(`Error: ${message}`)
+  process.exit(1)
+}
+
+/** Labels become directory names under bench-results/ — keep them path-safe. */
+function assertValidLabel(label: string): void {
+  if (!/^[A-Za-z0-9][A-Za-z0-9._-]*$/.test(label)) {
+    fail(`invalid label "${label}" — use letters, digits, dots, dashes, or underscores`)
+  }
+}
+
+function assertRequiredEnv(): void {
+  const missing = REQUIRED_ENV_VARS.filter((name) => !process.env[name]?.trim())
+  if (missing.length === 0) return
+
+  fail(
+    `missing required environment variable(s): ${missing.join(', ')}.\n` +
+      'Set them in .env.local (see .env.example for the full list) or export them ' +
+      'before running the benchmark.'
+  )
+}
+
+function collectStages(graph: EtymologyResult['ancestryGraph']): AncestryStage[] {
+  const stages = graph.branches.flatMap((branch) => branch.stages)
+  return graph.postMerge ? [...stages, ...graph.postMerge] : stages
+}
+
+function distributeConfidence(stages: AncestryStage[]): ConfidenceDistribution {
+  const distribution: ConfidenceDistribution = { high: 0, medium: 0, low: 0, unscored: 0 }
+  for (const stage of stages) {
+    distribution[stage.confidence ?? 'unscored'] += 1
+  }
+  return distribution
+}
+
+function countUngroundedReconstructed(stages: AncestryStage[]): number {
+  let count = 0
+  for (const stage of stages) {
+    if (stage.isReconstructed && (stage.evidence?.length ?? 0) === 0) {
+      count += 1
+    }
+  }
+  return count
+}
+
+/**
+ * Temporarily override the synthesis model. CONFIG's `as const` is type-level
+ * only — the underlying object is mutable at runtime, and buildSynthesisRequest
+ * reads CONFIG.model at call time. Root extraction (inside research) keeps the
+ * default model; only the synthesis call is affected, matching the bake-off intent.
+ */
+async function withModelOverride<T>(model: string | undefined, fn: () => Promise<T>): Promise<T> {
+  if (!model) return fn()
+
+  const mutableConfig = CONFIG as unknown as { model: string }
+  const originalModel = mutableConfig.model
+  mutableConfig.model = model
+  try {
+    return await fn()
+  } finally {
+    mutableConfig.model = originalModel
+  }
+}
+
+async function benchmarkWord(
+  word: string,
+  bucket: Bucket,
+  model: string | undefined,
+  outputDir: string
+): Promise<WordBenchmark> {
+  const marks: { parsingDone?: number; rootsDone?: number } = {}
+  const startedAt = performance.now()
+
+  try {
+    const context = await conductAgenticResearch(word, undefined, (event) => {
+      if (event.type === 'parsing_complete') marks.parsingDone = performance.now()
+      if (event.type === 'roots_identified') marks.rootsDone = performance.now()
+    })
+    const researchDone = performance.now()
+
+    const { result, usage } = await withModelOverride(model, () => synthesizeFromResearch(context))
+    const synthesisDone = performance.now()
+
+    const stages = collectStages(result.ancestryGraph)
+    const parsingDone = marks.parsingDone ?? researchDone
+    const rootsDone = marks.rootsDone ?? parsingDone
+
+    const record: WordBenchmark = {
+      word,
+      bucket,
+      ok: true,
+      schemaValid: EtymologyResultSchema.safeParse(result).success,
+      latencyMs: {
+        sourceFetch: Math.round(parsingDone - startedAt),
+        rootExtraction: Math.round(rootsDone - parsingDone),
+        expansion: Math.round(researchDone - rootsDone),
+        research: Math.round(researchDone - startedAt),
+        synthesis: Math.round(synthesisDone - researchDone),
+        total: Math.round(synthesisDone - startedAt),
+      },
+      tokens: { input: usage.inputTokens, output: usage.outputTokens },
+      rootCount: result.roots.length,
+      ancestryStageCount: stages.length,
+      confidence: distributeConfidence(stages),
+      ungroundedReconstructedStages: countUngroundedReconstructed(stages),
+      lore: result.lore,
+    }
+
+    writeFileSync(join(outputDir, `${word}.json`), JSON.stringify({ ...record, result }, null, 2))
+    return record
+  } catch (error) {
+    return {
+      word,
+      bucket,
+      ok: false,
+      error: safeError(error),
+      schemaValid: false,
+      latencyMs: {
+        sourceFetch: 0,
+        rootExtraction: 0,
+        expansion: 0,
+        research: 0,
+        synthesis: 0,
+        total: Math.round(performance.now() - startedAt),
+      },
+      tokens: { input: 0, output: 0 },
+      rootCount: 0,
+      ancestryStageCount: 0,
+      confidence: { high: 0, medium: 0, low: 0, unscored: 0 },
+      ungroundedReconstructedStages: 0,
+      lore: '',
+    }
+  }
+}
+
+function formatWordLine(record: WordBenchmark): string {
+  if (!record.ok) {
+    return `FAIL ${record.word} [${record.bucket}] ${record.error}`
+  }
+
+  const { confidence: c, latencyMs } = record
+  const seconds = (latencyMs.total / 1000).toFixed(1)
+  return (
+    `ok   ${record.word} [${record.bucket}] ${seconds}s | ` +
+    `${record.tokens.input} in / ${record.tokens.output} out tok | ` +
+    `${record.rootCount} roots, ${record.ancestryStageCount} stages ` +
+    `(${c.high}h/${c.medium}m/${c.low}l/${c.unscored}u) | ` +
+    `${record.ungroundedReconstructedStages} ungrounded reconstructed`
+  )
+}
+
+async function runBenchmark(label: string, model: string | undefined): Promise<void> {
+  assertValidLabel(label)
+  assertRequiredEnv()
+
+  const outputDir = join(RESULTS_DIR, label)
+  if (existsSync(outputDir)) {
+    fail(
+      `bench-results/${label}/ already exists. Pick a fresh --label or delete the ` +
+        'old directory to avoid mixing runs.'
+    )
+  }
+  mkdirSync(outputDir, { recursive: true })
+
+  const effectiveModel = model ?? CONFIG.model
+  console.log(`Benchmark run "${label}" | synthesis model: ${effectiveModel}`)
+  console.log(`Words: ${BENCHMARK_WORDS.length} | output: bench-results/${label}/\n`)
+
+  const startedAt = new Date()
+  const runStart = performance.now()
+  const words: WordBenchmark[] = []
+
+  for (const { word, bucket } of BENCHMARK_WORDS) {
+    const record = await benchmarkWord(word, bucket, model, outputDir)
+    words.push(record)
+    console.log(formatWordLine(record))
+  }
+
+  const summary: BenchmarkSummary = {
+    label,
+    model: effectiveModel,
+    startedAt: startedAt.toISOString(),
+    durationMs: Math.round(performance.now() - runStart),
+    words,
+  }
+  writeFileSync(join(outputDir, 'summary.json'), JSON.stringify(summary, null, 2))
+
+  console.log(`\n${formatAggregates(summary)}`)
+  console.log(`\nWrote bench-results/${label}/summary.json (+${words.length} per-word files)`)
+}
+
+interface Aggregates {
+  okCount: number
+  schemaValidCount: number
+  inputTokens: number
+  outputTokens: number
+  totalLatencyP50: number
+  synthesisLatencyP50: number
+  ungroundedReconstructed: number
+  confidence: ConfidenceDistribution
+}
+
+function percentile(sorted: number[], fraction: number): number {
+  if (sorted.length === 0) return 0
+  const index = Math.min(sorted.length - 1, Math.floor(fraction * sorted.length))
+  return sorted[index] ?? 0
+}
+
+function aggregate(summary: BenchmarkSummary): Aggregates {
+  const okRecords = summary.words.filter((record) => record.ok)
+  const totals = okRecords.map((record) => record.latencyMs.total).sort((a, b) => a - b)
+  const synthesis = okRecords.map((record) => record.latencyMs.synthesis).sort((a, b) => a - b)
+
+  const confidence: ConfidenceDistribution = { high: 0, medium: 0, low: 0, unscored: 0 }
+  for (const record of okRecords) {
+    confidence.high += record.confidence.high
+    confidence.medium += record.confidence.medium
+    confidence.low += record.confidence.low
+    confidence.unscored += record.confidence.unscored
+  }
+
+  return {
+    okCount: okRecords.length,
+    schemaValidCount: summary.words.filter((record) => record.schemaValid).length,
+    inputTokens: okRecords.reduce((sum, record) => sum + record.tokens.input, 0),
+    outputTokens: okRecords.reduce((sum, record) => sum + record.tokens.output, 0),
+    totalLatencyP50: percentile(totals, 0.5),
+    synthesisLatencyP50: percentile(synthesis, 0.5),
+    ungroundedReconstructed: okRecords.reduce(
+      (sum, record) => sum + record.ungroundedReconstructedStages,
+      0
+    ),
+    confidence,
+  }
+}
+
+function formatAggregates(summary: BenchmarkSummary): string {
+  const agg = aggregate(summary)
+  const total = summary.words.length
+  const c = agg.confidence
+  return [
+    `Completed: ${agg.okCount}/${total} | schema-valid: ${agg.schemaValidCount}/${total}`,
+    `Tokens: ${agg.inputTokens} in / ${agg.outputTokens} out`,
+    `Latency p50: ${agg.totalLatencyP50}ms total, ${agg.synthesisLatencyP50}ms synthesis`,
+    `Confidence: ${c.high} high / ${c.medium} medium / ${c.low} low / ${c.unscored} unscored`,
+    `Ungrounded reconstructed stages: ${agg.ungroundedReconstructed}`,
+  ].join('\n')
+}
+
+function loadSummary(label: string): BenchmarkSummary {
+  assertValidLabel(label)
+  const path = join(RESULTS_DIR, label, 'summary.json')
+  if (!existsSync(path)) {
+    fail(`no summary found at bench-results/${label}/summary.json — run the benchmark first`)
+  }
+  return JSON.parse(readFileSync(path, 'utf8')) as BenchmarkSummary
+}
+
+function compareRow(metric: string, a: number, b: number): string {
+  const delta = b - a
+  const sign = delta > 0 ? '+' : ''
+  return `${metric.padEnd(34)} ${String(a).padStart(10)} ${String(b).padStart(10)} ${(
+    sign + delta
+  ).padStart(10)}`
+}
+
+function compareLabels(labelA: string, labelB: string): void {
+  const summaryA = loadSummary(labelA)
+  const summaryB = loadSummary(labelB)
+  const aggA = aggregate(summaryA)
+  const aggB = aggregate(summaryB)
+
+  console.log(`Comparing "${labelA}" (model ${summaryA.model})`)
+  console.log(`   vs     "${labelB}" (model ${summaryB.model})\n`)
+  console.log(
+    `${'metric'.padEnd(34)} ${labelA.slice(0, 10).padStart(10)} ` +
+      `${labelB.slice(0, 10).padStart(10)} ${'delta'.padStart(10)}`
+  )
+
+  console.log(compareRow('completed words', aggA.okCount, aggB.okCount))
+  console.log(compareRow('schema-valid words', aggA.schemaValidCount, aggB.schemaValidCount))
+  console.log(compareRow('input tokens (total)', aggA.inputTokens, aggB.inputTokens))
+  console.log(compareRow('output tokens (total)', aggA.outputTokens, aggB.outputTokens))
+  console.log(compareRow('latency p50 total (ms)', aggA.totalLatencyP50, aggB.totalLatencyP50))
+  console.log(
+    compareRow('latency p50 synthesis (ms)', aggA.synthesisLatencyP50, aggB.synthesisLatencyP50)
+  )
+  console.log(compareRow('confidence: high', aggA.confidence.high, aggB.confidence.high))
+  console.log(compareRow('confidence: medium', aggA.confidence.medium, aggB.confidence.medium))
+  console.log(compareRow('confidence: low', aggA.confidence.low, aggB.confidence.low))
+  console.log(
+    compareRow('confidence: unscored', aggA.confidence.unscored, aggB.confidence.unscored)
+  )
+  console.log(
+    compareRow(
+      'ungrounded reconstructed stages',
+      aggA.ungroundedReconstructed,
+      aggB.ungroundedReconstructed
+    )
+  )
+
+  console.log('\nPer-word total latency (ms) and schema validity:')
+  for (const { word } of BENCHMARK_WORDS) {
+    const a = summaryA.words.find((record) => record.word === word)
+    const b = summaryB.words.find((record) => record.word === word)
+    const validA = a ? (a.schemaValid ? 'valid' : 'INVALID') : 'missing'
+    const validB = b ? (b.schemaValid ? 'valid' : 'INVALID') : 'missing'
+    console.log(
+      `${word.padEnd(16)} ${String(a?.latencyMs.total ?? '-').padStart(8)} -> ` +
+        `${String(b?.latencyMs.total ?? '-').padStart(8)}   ${validA} -> ${validB}`
+    )
+  }
+}
+
+function printHelp(): void {
+  console.log(`Etymology pipeline quality benchmark
+
+Usage:
+  bun scripts/benchmark.ts --label <name> [--model <openrouter-slug>]
+  bun scripts/benchmark.ts --compare <labelA> <labelB>
+  bun scripts/benchmark.ts --help
+
+Options:
+  --label <name>    Name for this run; results go to bench-results/<name>/ (gitignored).
+                    Defaults to run-<timestamp>.
+  --model <slug>    Override the synthesis model (e.g. deepseek/deepseek-v4-pro).
+                    Root extraction keeps the default model.
+  --compare <a> <b> Print a comparison table for two prior runs. Makes no API calls.
+  --help            Show this help.
+
+A full run benchmarks ${BENCHMARK_WORDS.length} words (~2 LLM calls each, roughly $0.02/word).
+Requires ${REQUIRED_ENV_VARS.join(', ')} in the environment (.env.local works).`)
+}
+
+async function main(): Promise<void> {
+  const { values, positionals } = parseArgs({
+    args: process.argv.slice(2),
+    options: {
+      label: { type: 'string' },
+      model: { type: 'string' },
+      compare: { type: 'string' },
+      help: { type: 'boolean', short: 'h' },
+    },
+    allowPositionals: true,
+  })
+
+  if (values.help) {
+    printHelp()
+    return
+  }
+
+  if (values.compare) {
+    const labels = [values.compare, ...positionals]
+    if (labels.length !== 2) {
+      fail('--compare needs exactly two labels: --compare <labelA> <labelB>')
+    }
+    compareLabels(labels[0]!, labels[1]!)
+    return
+  }
+
+  if (positionals.length > 0) {
+    fail(`unexpected arguments: ${positionals.join(' ')} (see --help)`)
+  }
+
+  const timestamp = new Date().toISOString().replace(/[:.]/g, '-').slice(0, 19)
+  await runBenchmark(values.label ?? `run-${timestamp}`, values.model)
+}
+
+main().catch((error) => {
+  fail(safeError(error))
+})


### PR DESCRIPTION
## What this does

- **package.json**: adds `test` (`bun test`) and `typecheck` (`tsc --noEmit`) scripts, pins `packageManager` to `bun@1.3.10`, and adds `@types/bun` so the existing `bun:test` suites (previously orphaned — no script, no CI) pass the typecheck.
- **CI**: new `.github/workflows/test.yml` with `test` and `typecheck` jobs, matching the existing workflows (SHA-pinned actions with version comments, `contents: read` permissions, cancel-in-progress concurrency, bun via oven-sh/setup-bun).
- **Workflow hardening**: adds `persist-credentials: false` to every `actions/checkout` step across all three workflows (test.yml, build.yml, lint-format.yml) — none of them push or use the token after checkout. Clears the zizmor `artipacked` findings; zizmor now reports zero findings on `.github/workflows/`.
- **`scripts/benchmark.ts`**: in-process quality benchmark over 15 words in 4 buckets (classical, Germanic, neologism, tricky). Per word it records Zod schema validity, per-phase latency (source fetch / root extraction / expansion / synthesis), input/output tokens, root count, ancestry stage count, confidence distribution, ungrounded reconstructed stages, and lore text. `--label` writes JSON to gitignored `bench-results/<label>/`, `--model` overrides the synthesis model, `--compare <a> <b>` prints an offline comparison table (no API calls). Required env vars are validated at startup by name only (values never printed).
- **`lib/schemas/etymology.test.ts`**: smoke test asserting `EtymologyResultSchema` parses a known-good fixture, preserves unknown fields, and rejects missing core fields / invalid confidence values.
- **.gitignore**: adds `bench-results/`.

## Verification

- `bun test`: 23 pass, 0 fail (19 pre-existing + 4 new)
- `bun run lint`, `bun run typecheck`, `bun run format:check`, `bun run build`: all green
- `actionlint` + `zizmor` on `.github/workflows/`: clean, zero findings
- Benchmark dry-run: `--help`, missing-env error path, and `--compare` on fixture data verified; no paid LLM calls made

**Merge order: merge FIRST, before all other improvement PRs. Expected conflicts: package.json with chore/design-cleanup (trivial).**

https://claude.ai/code/session_012GTdDDmz56DHGedvS2suof