### PR TITLE
feat: crawlable /word pages with cache-only SSR, sitemap, and canonicals

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -121,6 +121,23 @@ Pipeline flow: Raw sources → Parser (CPU) → LLM (validates/extends) → Enri
 
 New optional fields on `AncestryStage`: `isReconstructed`, `confidence`, `evidence[]` (backward compatible)
 
+### SEO Word Pages
+
+Shareable, crawlable per-word pages that must never cost LLM money:
+
+- **`app/word/[word]/page.tsx`** - SSR strictly from `getCachedEtymology` (`lib/cache.ts`).
+  The module graph must never include `lib/research.ts`, `lib/llm.ts`, or
+  `lib/openrouterResponses.ts` — enforced by `app/word/import-graph.test.ts`. Cache miss
+  renders a noindex page with a "Trace it live" CTA to `/?q={word}`. ISR via
+  `revalidate = 86400`.
+- **`app/sitemap.ts`** - SCANs cached etymology keys (cursor-paginated, capped at 1000) using
+  the exported `CACHE_VERSION`/`ETYMOLOGY_PREFIX` constants from `lib/cache.ts`.
+- **`app/og/route.tsx`** - `/og?word={word}` renders a per-word OG card; without a valid
+  `word` it falls back to the brand card.
+- **Canonicals**: `/?q=word` canonicalizes to `/word/{word}` (`app/page.tsx`
+  `generateMetadata`); bare `/` keeps canonical `/`. `ShareMenu` copies `/word/{word}` links.
+  Client search UX stays on `/?q=`.
+
 ### Research Pipeline Limits
 
 Configured in `lib/config.ts` (consumed by `lib/research.ts`) to control API costs:
@@ -253,6 +270,12 @@ All return `{ success: boolean, data?: T, error?: string }` wrapper.
 - `lib/urbanDictionary.ts` - Urban Dictionary API with quality scoring/filtering
 - `lib/incelsWiki.ts` - Incel Wiki MediaWiki API client (supplemental context)
 - `lib/elevenlabs.ts` - ElevenLabs TTS client
+
+**SEO Word Pages:**
+
+- `app/word/[word]/page.tsx` - Cache-only SSR word pages (import graph must exclude research/LLM)
+- `app/word/import-graph.test.ts` - Enforces the no-LLM-in-module-graph budget invariant
+- `components/WordPageEntry.tsx` - Client shell reusing EtymologyCard for /word pages
 
 **Admin:**
 

--- a/README.md
+++ b/README.md
@@ -21,6 +21,8 @@ Try it out at [etymex.com](https://etymex.com)
 - **Streaming UI**: Optional `?stream=true` server-sent events for source progress,
   token streaming, cached hits, and early error responses
 - **Smart Caching**: Redis-backed caching reduces costs and improves speed (30d etymology, 1yr audio)
+- **Shareable Word Pages**: Crawlable `/word/{word}` pages served strictly from the cache
+  (never trigger LLM spend), with per-word OG images and sitemap listings
 - **Rate Limiting**: Per-IP protection via Upstash Redis with automatic budget enforcement
 
 ## Getting Started
@@ -123,8 +125,9 @@ etymology-explorer/
 │   ├── faq/                # FAQ page with structured data
 │   ├── learn/              # Educational content pages
 │   │   └── what-is-etymology/
-│   ├── og/                 # Dynamic OG image generation
-│   ├── sitemap.ts          # Dynamic sitemap
+│   ├── og/                 # Dynamic OG image generation (brand + per-word cards)
+│   ├── word/[word]/        # Cache-only SSR word pages (SEO; never call the LLM)
+│   ├── sitemap.ts          # Dynamic sitemap (static pages + cached /word/ entries)
 │   ├── robots.ts           # Robots.txt configuration
 │   ├── layout.tsx          # Root layout with fonts
 │   └── page.tsx            # Main page with search UI

--- a/app/og/route.tsx
+++ b/app/og/route.tsx
@@ -2,6 +2,7 @@ import { readFile } from 'node:fs/promises'
 import { join } from 'node:path'
 import { ImageResponse } from 'next/og'
 import { SITE_HOST, SITE_SHORT_NAME } from '@/lib/site'
+import { canonicalizeWord, isValidWord } from '@/lib/validation'
 
 const fontDirectory = join(process.cwd(), 'public/fonts')
 
@@ -10,10 +11,17 @@ const brandFontData = Promise.all([
   readFile(join(fontDirectory, 'LibreBaskerville-Italic.ttf')),
 ])
 
-export async function GET() {
-  const [regularFont, italicFont] = await brandFontData
+const IMAGE_OPTIONS = { width: 1200, height: 630 }
 
-  return new ImageResponse(
+function wordFontSize(word: string): number {
+  if (word.length <= 10) return 148
+  if (word.length <= 16) return 112
+  if (word.length <= 24) return 84
+  return 62
+}
+
+function BrandCard() {
+  return (
     <div
       style={{
         width: '100%',
@@ -85,24 +93,105 @@ export async function GET() {
       >
         {`${SITE_SHORT_NAME} · ${SITE_HOST}`}
       </div>
-    </div>,
-    {
-      width: 1200,
-      height: 630,
-      fonts: [
-        {
-          name: 'Libre Baskerville',
-          data: regularFont,
-          weight: 400,
-          style: 'normal',
-        },
-        {
-          name: 'Libre Baskerville',
-          data: italicFont,
-          weight: 400,
-          style: 'italic',
-        },
-      ],
-    }
+    </div>
   )
+}
+
+function WordCard({ word }: { word: string }) {
+  return (
+    <div
+      style={{
+        width: '100%',
+        height: '100%',
+        display: 'flex',
+        flexDirection: 'column',
+        alignItems: 'center',
+        justifyContent: 'center',
+        backgroundColor: '#F6F1E6',
+        fontFamily: 'Libre Baskerville',
+        padding: 80,
+      }}
+    >
+      <div
+        style={{
+          display: 'flex',
+          fontSize: 26,
+          textTransform: 'uppercase',
+          letterSpacing: '0.24em',
+          color: '#1B1A17',
+          opacity: 0.6,
+          marginBottom: 34,
+        }}
+      >
+        the etymology of
+      </div>
+      <div
+        style={{
+          display: 'flex',
+          fontSize: wordFontSize(word),
+          fontStyle: 'italic',
+          color: '#1B1A17',
+          letterSpacing: '-0.04em',
+          lineHeight: 1.05,
+          maxWidth: 1040,
+        }}
+      >
+        <span style={{ color: '#7E2A1F' }}>{word.slice(0, 1)}</span>
+        <span>{word.slice(1)}</span>
+      </div>
+      <div
+        style={{
+          display: 'flex',
+          alignItems: 'center',
+          gap: 14,
+          marginTop: 44,
+          color: '#1B1A17',
+          opacity: 0.35,
+        }}
+      >
+        <div style={{ width: 48, height: 1, backgroundColor: '#1B1A17' }} />
+        <div style={{ fontSize: 22, fontStyle: 'italic' }}>§</div>
+        <div style={{ width: 48, height: 1, backgroundColor: '#1B1A17' }} />
+      </div>
+      <div
+        style={{
+          position: 'absolute',
+          bottom: 48,
+          fontSize: 18,
+          color: '#1B1A17',
+          opacity: 0.48,
+        }}
+      >
+        {`${SITE_SHORT_NAME} · ${SITE_HOST}`}
+      </div>
+    </div>
+  )
+}
+
+export async function GET(request: Request) {
+  const [regularFont, italicFont] = await brandFontData
+
+  const fonts = [
+    {
+      name: 'Libre Baskerville',
+      data: regularFont,
+      weight: 400 as const,
+      style: 'normal' as const,
+    },
+    {
+      name: 'Libre Baskerville',
+      data: italicFont,
+      weight: 400 as const,
+      style: 'italic' as const,
+    },
+  ]
+
+  const rawWord = new URL(request.url).searchParams.get('word')
+  const word = rawWord ? canonicalizeWord(rawWord) : ''
+
+  if (word && isValidWord(word)) {
+    return new ImageResponse(<WordCard word={word} />, { ...IMAGE_OPTIONS, fonts })
+  }
+
+  return new ImageResponse(<BrandCard />, { ...IMAGE_OPTIONS, fonts })
 }

--- a/app/og/route.tsx
+++ b/app/og/route.tsx
@@ -6,12 +6,30 @@ import { canonicalizeWord, isValidWord } from '@/lib/validation'
 
 const fontDirectory = join(process.cwd(), 'public/fonts')
 
-const brandFontData = Promise.all([
-  readFile(join(fontDirectory, 'LibreBaskerville-Regular.ttf')),
-  readFile(join(fontDirectory, 'LibreBaskerville-Italic.ttf')),
-])
+// Lazy + memoized so a failed read rejects inside the request handler
+// (500 for that request) instead of as an unhandled rejection at module load
+let brandFontData: Promise<[Buffer, Buffer]> | null = null
+
+function loadBrandFonts(): Promise<[Buffer, Buffer]> {
+  brandFontData ??= Promise.all([
+    readFile(join(fontDirectory, 'LibreBaskerville-Regular.ttf')),
+    readFile(join(fontDirectory, 'LibreBaskerville-Italic.ttf')),
+  ]).catch((error) => {
+    brandFontData = null // allow retry on transient failures
+    throw error
+  })
+  return brandFontData
+}
 
 const IMAGE_OPTIONS = { width: 1200, height: 630 }
+
+/** Split off the first grapheme (accent-colored) without breaking surrogate
+ *  pairs or detaching combining diacritics from their base letter. */
+function splitLeadingGrapheme(word: string): [string, string] {
+  const segmenter = new Intl.Segmenter(undefined, { granularity: 'grapheme' })
+  const graphemes = Array.from(segmenter.segment(word), (segment) => segment.segment)
+  return [graphemes[0] ?? '', graphemes.slice(1).join('')]
+}
 
 function wordFontSize(word: string): number {
   if (word.length <= 10) return 148
@@ -98,6 +116,7 @@ function BrandCard() {
 }
 
 function WordCard({ word }: { word: string }) {
+  const [initial, rest] = splitLeadingGrapheme(word)
   return (
     <div
       style={{
@@ -136,8 +155,8 @@ function WordCard({ word }: { word: string }) {
           maxWidth: 1040,
         }}
       >
-        <span style={{ color: '#7E2A1F' }}>{word.slice(0, 1)}</span>
-        <span>{word.slice(1)}</span>
+        <span style={{ color: '#7E2A1F' }}>{initial}</span>
+        <span>{rest}</span>
       </div>
       <div
         style={{
@@ -169,7 +188,7 @@ function WordCard({ word }: { word: string }) {
 }
 
 export async function GET(request: Request) {
-  const [regularFont, italicFont] = await brandFontData
+  const [regularFont, italicFont] = await loadBrandFonts()
 
   const fonts = [
     {

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,5 +1,26 @@
+import type { Metadata } from 'next'
 import { Suspense } from 'react'
 import { ExploreExperience } from '@/components/ExploreExperience'
+import { canonicalizeWord, isValidWord } from '@/lib/validation'
+
+interface HomePageProps {
+  searchParams: Promise<{ q?: string | string[] }>
+}
+
+/**
+ * Deep-linked searches (/?q=word) canonicalize to the crawlable /word/{word}
+ * page so search engines index one URL per word; bare / keeps canonical /.
+ */
+export async function generateMetadata({ searchParams }: HomePageProps): Promise<Metadata> {
+  const { q } = await searchParams
+  const raw = Array.isArray(q) ? q[0] : q
+  if (!raw) return { alternates: { canonical: '/' } }
+
+  const word = canonicalizeWord(raw)
+  if (!isValidWord(word)) return { alternates: { canonical: '/' } }
+
+  return { alternates: { canonical: `/word/${encodeURIComponent(word)}` } }
+}
 
 export default function Home() {
   return (

--- a/app/sitemap.ts
+++ b/app/sitemap.ts
@@ -1,8 +1,59 @@
 import type { MetadataRoute } from 'next'
+import { unstable_cache } from 'next/cache'
+import { ETYMOLOGY_PREFIX } from '@/lib/cache'
+import { safeError } from '@/lib/errorUtils'
+import { getRedis } from '@/lib/redis'
 import { SITE_ORIGIN } from '@/lib/site'
+import { isValidWord } from '@/lib/validation'
 
-export default function sitemap(): MetadataRoute.Sitemap {
-  return [
+export const revalidate = 86400
+
+// Cap sitemap size: SCAN stops once this many cached words are collected
+const MAX_WORD_ENTRIES = 1000
+const SCAN_BATCH_SIZE = 200
+
+/**
+ * Collect words with cached etymology entries by cursor-scanning Redis keys
+ * under the versioned etymology prefix. Fails open to an empty list so the
+ * static sitemap entries always ship.
+ */
+async function scanCachedWords(): Promise<string[]> {
+  const redis = getRedis()
+  if (!redis) return []
+
+  const words = new Set<string>()
+  let cursor = '0'
+  try {
+    do {
+      const [nextCursor, keys] = await redis.scan(cursor, {
+        match: `${ETYMOLOGY_PREFIX}*`,
+        count: SCAN_BATCH_SIZE,
+      })
+      cursor = String(nextCursor)
+      for (const key of keys) {
+        const word = key.slice(ETYMOLOGY_PREFIX.length)
+        if (isValidWord(word)) {
+          words.add(word)
+        }
+        if (words.size >= MAX_WORD_ENTRIES) {
+          return Array.from(words)
+        }
+      }
+    } while (cursor !== '0')
+  } catch (error) {
+    console.error('[Sitemap] Redis scan failed:', safeError(error))
+  }
+  return Array.from(words)
+}
+
+// unstable_cache keeps the Upstash client's no-store fetches from flipping
+// the sitemap route to dynamic; the word list revalidates daily.
+const getCachedWords = unstable_cache(scanCachedWords, ['sitemap-cached-words'], {
+  revalidate: 86400,
+})
+
+export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
+  const staticEntries: MetadataRoute.Sitemap = [
     {
       url: SITE_ORIGIN,
       lastModified: new Date(),
@@ -22,4 +73,14 @@ export default function sitemap(): MetadataRoute.Sitemap {
       priority: 0.7,
     },
   ]
+
+  const words = await getCachedWords()
+  const wordEntries: MetadataRoute.Sitemap = words.sort().map((word) => ({
+    url: `${SITE_ORIGIN}/word/${encodeURIComponent(word)}`,
+    lastModified: new Date(),
+    changeFrequency: 'monthly',
+    priority: 0.6,
+  }))
+
+  return [...staticEntries, ...wordEntries]
 }

--- a/app/sitemap.ts
+++ b/app/sitemap.ts
@@ -75,7 +75,8 @@ export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
   ]
 
   const words = await getCachedWords()
-  const wordEntries: MetadataRoute.Sitemap = words.sort().map((word) => ({
+  // Copy before sorting: unstable_cache may hand back a shared in-memory array
+  const wordEntries: MetadataRoute.Sitemap = [...words].sort().map((word) => ({
     url: `${SITE_ORIGIN}/word/${encodeURIComponent(word)}`,
     lastModified: new Date(),
     changeFrequency: 'monthly',

--- a/app/word/[word]/page.tsx
+++ b/app/word/[word]/page.tsx
@@ -1,0 +1,167 @@
+import type { Metadata } from 'next'
+import { unstable_cache } from 'next/cache'
+import Link from 'next/link'
+import { notFound } from 'next/navigation'
+import { EditorialPageFrame } from '@/components/EditorialPageFrame'
+import { SiteFooter } from '@/components/SiteFooter'
+import { SiteHeader } from '@/components/SiteHeader'
+import { WordPageEntry } from '@/components/WordPageEntry'
+import { getCachedEtymology } from '@/lib/cache'
+import { SITE_SHORT_NAME } from '@/lib/site'
+import type { EtymologyResult } from '@/lib/types'
+import { canonicalizeWord, isValidWord } from '@/lib/validation'
+
+// Shareable, crawlable word pages served STRICTLY from the Redis cache.
+// This module's import graph must never include lib/research.ts or lib/llm.ts
+// (enforced by app/word/import-graph.test.ts) so crawler traffic cannot
+// trigger LLM spend. Cache misses render a noindex page with a live-trace CTA.
+export const revalidate = 86400
+
+// No build-time prerenders; paths are generated on demand and ISR-cached
+export function generateStaticParams(): Array<{ word: string }> {
+  return []
+}
+
+const DESCRIPTION_MAX_CHARS = 155
+
+// Redis reads go through unstable_cache: the Upstash client issues no-store
+// fetches, which would otherwise flip this ISR route to dynamic at runtime
+// (app-static-to-dynamic-error). Entries revalidate daily alongside the page.
+const loadCachedEtymology = unstable_cache(getCachedEtymology, ['word-page-etymology'], {
+  revalidate: 86400,
+})
+
+interface WordPageProps {
+  params: Promise<{ word: string }>
+}
+
+function resolveWord(rawParam: string): string | null {
+  let decoded: string
+  try {
+    decoded = decodeURIComponent(rawParam)
+  } catch {
+    return null
+  }
+  const word = canonicalizeWord(decoded)
+  return isValidWord(word) ? word : null
+}
+
+function truncateAtWordBoundary(text: string, maxChars: number): string {
+  if (text.length <= maxChars) return text
+  const cut = text.slice(0, maxChars + 1)
+  const lastSpace = cut.lastIndexOf(' ')
+  const trimmed = (lastSpace > 0 ? cut.slice(0, lastSpace) : cut.slice(0, maxChars)).replace(
+    /[\s,;:.–—-]+$/,
+    ''
+  )
+  return `${trimmed}…`
+}
+
+function buildWordDescription(result: EtymologyResult): string {
+  const combined = [result.definition, result.lore]
+    .filter(Boolean)
+    .join(' ')
+    .replace(/\s+/g, ' ')
+    .trim()
+  return truncateAtWordBoundary(combined, DESCRIPTION_MAX_CHARS)
+}
+
+export async function generateMetadata({ params }: WordPageProps): Promise<Metadata> {
+  const { word: rawWord } = await params
+  const word = resolveWord(rawWord)
+  if (!word) notFound()
+
+  const title = `Etymology of ${word} — ${SITE_SHORT_NAME}`
+  const canonicalPath = `/word/${encodeURIComponent(word)}`
+  const result = await loadCachedEtymology(word)
+
+  if (!result) {
+    return {
+      title: { absolute: title },
+      description: `The etymology of “${word}” has not been traced yet. Run a live trace on ${SITE_SHORT_NAME} to follow it back to its roots.`,
+      robots: { index: false, follow: true },
+      alternates: { canonical: canonicalPath },
+    }
+  }
+
+  const description = buildWordDescription(result)
+  const ogImage = `/og?word=${encodeURIComponent(word)}`
+
+  return {
+    title: { absolute: title },
+    description,
+    alternates: { canonical: canonicalPath },
+    openGraph: {
+      title,
+      description,
+      url: canonicalPath,
+      siteName: SITE_SHORT_NAME,
+      type: 'article',
+      images: [{ url: ogImage, width: 1200, height: 630, alt: `Etymology of ${word}` }],
+    },
+    twitter: {
+      card: 'summary_large_image',
+      title,
+      description,
+      images: [ogImage],
+    },
+  }
+}
+
+function UntracedWordPage({ word }: { word: string }) {
+  return (
+    <EditorialPageFrame
+      eyebrow="uncharted entry"
+      title={word}
+      subtitle="This word has not been traced in the archive yet. Its older forms and borrowed meanings are still waiting to be followed back."
+    >
+      <section className="mx-auto max-w-3xl">
+        <div className="editorial-card flex flex-col gap-6 p-8 sm:flex-row sm:items-center sm:justify-between">
+          <div>
+            <p className="font-serif text-xl italic text-charcoal-light">no entry on file</p>
+            <p className="mt-2 font-serif text-3xl tracking-[-0.03em] text-charcoal">
+              Trace it live and watch the roots surface.
+            </p>
+          </div>
+          <Link
+            href={`/?q=${encodeURIComponent(word)}`}
+            className="editorial-chip self-start font-serif italic sm:self-center"
+          >
+            Trace &ldquo;{word}&rdquo; live &rarr;
+          </Link>
+        </div>
+      </section>
+    </EditorialPageFrame>
+  )
+}
+
+export default async function WordPage({ params }: WordPageProps) {
+  const { word: rawWord } = await params
+  const word = resolveWord(rawWord)
+  if (!word) notFound()
+
+  const result = await loadCachedEtymology(word)
+  if (!result) {
+    return <UntracedWordPage word={word} />
+  }
+
+  return (
+    <div className="min-h-screen bg-cream text-charcoal">
+      <SiteHeader compact />
+      <main className="mx-auto max-w-[1180px] px-4 pb-16 pt-10 sm:px-6 lg:px-8 lg:pt-14">
+        <Link
+          href="/"
+          className="editorial-link inline-flex items-center gap-2 text-[11px] uppercase tracking-[0.22em] text-charcoal-light/72 transition-colors hover:text-charcoal"
+        >
+          <span aria-hidden="true">&larr;</span>
+          <span>Back to explorer</span>
+        </Link>
+
+        <div className="mt-8">
+          <WordPageEntry result={result} />
+        </div>
+      </main>
+      <SiteFooter />
+    </div>
+  )
+}

--- a/app/word/[word]/page.tsx
+++ b/app/word/[word]/page.tsx
@@ -26,15 +26,25 @@ const DESCRIPTION_MAX_CHARS = 155
 
 // Redis reads go through unstable_cache: the Upstash client issues no-store
 // fetches, which would otherwise flip this ISR route to dynamic at runtime
-// (app-static-to-dynamic-error). Entries revalidate daily alongside the page.
-const loadCachedEtymology = unstable_cache(getCachedEtymology, ['word-page-etymology'], {
-  revalidate: 86400,
-})
+// (app-static-to-dynamic-error). The data layer revalidates hourly so a
+// cached miss doesn't compound with the 24h page ISR window once a word is
+// traced live; the per-word tag lets the trace-write path call
+// revalidateTag(`etymology-word:${word}`) to surface new entries immediately.
+function loadCachedEtymology(word: string): Promise<EtymologyResult | null> {
+  return unstable_cache(() => getCachedEtymology(word), ['word-page-etymology', word], {
+    revalidate: 3600,
+    tags: [`etymology-word:${word}`],
+  })()
+}
 
 interface WordPageProps {
   params: Promise<{ word: string }>
 }
 
+// Next.js has changed whether dynamic params arrive percent-encoded across
+// versions (vercel/next.js#54916), so decode defensively: decoding an
+// already-decoded word is a no-op for every valid word ('%' never passes
+// isValidWord), and malformed sequences 404 via the catch.
 function resolveWord(rawParam: string): string | null {
   let decoded: string
   try {

--- a/app/word/import-graph.test.ts
+++ b/app/word/import-graph.test.ts
@@ -1,0 +1,84 @@
+import { describe, expect, test } from 'bun:test'
+import { existsSync, readFileSync, statSync } from 'node:fs'
+import { dirname, join, resolve } from 'node:path'
+
+/**
+ * Budget invariant: crawler traffic to /word/[word] must NEVER trigger LLM
+ * spend. This test statically walks the transitive import graph of the word
+ * page and asserts the research/LLM pipeline modules are absent.
+ */
+
+const REPO_ROOT = resolve(import.meta.dir, '..', '..')
+const ENTRY = join(REPO_ROOT, 'app', 'word', '[word]', 'page.tsx')
+
+const SOURCE_EXTENSIONS = ['.ts', '.tsx', '.js', '.jsx', '.mts']
+
+// Matches static imports/re-exports, dynamic import(), and side-effect imports
+const IMPORT_SPECIFIER_PATTERN =
+  /(?:import|export)\s[^'"]*?from\s*['"]([^'"]+)['"]|import\s*\(\s*['"]([^'"]+)['"]\s*\)|(?:^|\n)\s*import\s*['"]([^'"]+)['"]/g
+
+function resolveSpecifier(specifier: string, fromFile: string): string | null {
+  let base: string
+  if (specifier.startsWith('@/')) {
+    base = join(REPO_ROOT, specifier.slice(2))
+  } else if (specifier.startsWith('./') || specifier.startsWith('../')) {
+    base = resolve(dirname(fromFile), specifier)
+  } else {
+    return null // bare specifier (node_modules / builtins) — out of scope
+  }
+
+  const candidates = [
+    base,
+    ...SOURCE_EXTENSIONS.map((ext) => `${base}${ext}`),
+    ...SOURCE_EXTENSIONS.map((ext) => join(base, `index${ext}`)),
+  ]
+  for (const candidate of candidates) {
+    if (existsSync(candidate) && statSync(candidate).isFile()) {
+      return candidate
+    }
+  }
+  return null // non-source assets (css, json) — nothing to walk
+}
+
+function collectModuleGraph(entry: string): Set<string> {
+  const visited = new Set<string>()
+  const queue: string[] = [entry]
+
+  while (queue.length > 0) {
+    const file = queue.pop()
+    if (!file || visited.has(file)) continue
+    visited.add(file)
+    if (!SOURCE_EXTENSIONS.some((ext) => file.endsWith(ext))) continue
+
+    const source = readFileSync(file, 'utf8')
+    for (const match of source.matchAll(IMPORT_SPECIFIER_PATTERN)) {
+      const specifier = match[1] ?? match[2] ?? match[3]
+      if (!specifier) continue
+      const resolved = resolveSpecifier(specifier, file)
+      if (resolved) queue.push(resolved)
+    }
+  }
+
+  return visited
+}
+
+describe('/word/[word] module graph (LLM spend invariant)', () => {
+  const graph = collectModuleGraph(ENTRY)
+
+  test('walker traverses the page graph (sanity)', () => {
+    expect(graph.has(ENTRY)).toBe(true)
+    expect(graph.has(join(REPO_ROOT, 'lib', 'cache.ts'))).toBe(true)
+    expect(graph.has(join(REPO_ROOT, 'components', 'EtymologyCard.tsx'))).toBe(true)
+    expect(graph.size).toBeGreaterThan(10)
+  })
+
+  test('never imports the research or LLM pipeline', () => {
+    const forbidden = ['lib/research.ts', 'lib/llm.ts', 'lib/openrouterResponses.ts']
+    for (const relativePath of forbidden) {
+      const absolutePath = join(REPO_ROOT, relativePath)
+      // Guard: if the module was renamed, this test must be updated, not skipped
+      expect(existsSync(absolutePath)).toBe(true)
+      expect(graph.has(absolutePath)).toBe(false)
+    }
+  })
+})

--- a/app/word/page-metadata.test.ts
+++ b/app/word/page-metadata.test.ts
@@ -1,0 +1,94 @@
+import { describe, expect, mock, test } from 'bun:test'
+import type { EtymologyResult } from '@/lib/types'
+
+let cachedResult: EtymologyResult | null = null
+
+mock.module('@/lib/cache', () => ({
+  getCachedEtymology: async () => cachedResult,
+}))
+
+// unstable_cache needs Next's incremental cache runtime; pass functions through
+mock.module('next/cache', () => ({
+  unstable_cache: (fn: (...args: unknown[]) => unknown) => fn,
+}))
+
+const { generateMetadata } = await import('./[word]/page')
+
+const fixture: EtymologyResult = {
+  word: 'perfidious',
+  pronunciation: '/pərˈfɪdiəs/',
+  definition: 'Deceitful and untrustworthy; treacherous in matters of faith.',
+  roots: [
+    {
+      root: 'fides',
+      origin: 'Latin',
+      meaning: 'faith, trust',
+      relatedWords: ['fidelity', 'confide'],
+    },
+  ],
+  ancestryGraph: { branches: [] },
+  lore: 'Perfidious walked out of Latin per fidem decipere — to deceive through trust — and has named betrayers of promises ever since, from Roman rhetoric to the diplomatic insult perfidious Albion.',
+  sources: [
+    { name: 'etymonline', url: 'https://www.etymonline.com/word/perfidious', word: 'perfidious' },
+  ],
+}
+
+function paramsFor(word: string) {
+  return { params: Promise.resolve({ word }) }
+}
+
+describe('/word/[word] generateMetadata', () => {
+  test('cache hit: indexable metadata with canonical, description, and word OG image', async () => {
+    cachedResult = fixture
+    const metadata = await generateMetadata(paramsFor('perfidious'))
+
+    expect(metadata.title).toEqual({ absolute: 'Etymology of perfidious — EtymEx' })
+    expect(metadata.alternates?.canonical).toBe('/word/perfidious')
+    expect(metadata.robots).toBeUndefined()
+
+    expect(metadata.description).toStartWith('Deceitful and untrustworthy')
+    expect(metadata.description).toEndWith('…')
+    expect(metadata.description?.length).toBeLessThanOrEqual(156)
+
+    expect(metadata.openGraph?.images).toEqual([
+      {
+        url: '/og?word=perfidious',
+        width: 1200,
+        height: 630,
+        alt: 'Etymology of perfidious',
+      },
+    ])
+    const twitter = metadata.twitter as { card?: string; images?: unknown } | undefined
+    expect(twitter?.card).toBe('summary_large_image')
+    expect(twitter?.images).toEqual(['/og?word=perfidious'])
+  })
+
+  test('cache hit: canonicalizes mixed-case and percent-encoded params', async () => {
+    cachedResult = fixture
+    const metadata = await generateMetadata(paramsFor('Caf%C3%89'))
+
+    expect(metadata.alternates?.canonical).toBe(`/word/${encodeURIComponent('café')}`)
+    expect(metadata.title).toEqual({ absolute: 'Etymology of café — EtymEx' })
+  })
+
+  test('cache miss: noindex metadata with live-trace description', async () => {
+    cachedResult = null
+    const metadata = await generateMetadata(paramsFor('zymurgology'))
+
+    expect(metadata.robots).toEqual({ index: false, follow: true })
+    expect(metadata.alternates?.canonical).toBe('/word/zymurgology')
+    expect(metadata.title).toEqual({ absolute: 'Etymology of zymurgology — EtymEx' })
+    expect(metadata.description).toContain('has not been traced yet')
+    expect(metadata.openGraph).toBeUndefined()
+  })
+
+  test('invalid word: rejects via notFound', async () => {
+    cachedResult = null
+    await expect(generateMetadata(paramsFor('not%20a%20word%21%21'))).rejects.toThrow()
+  })
+
+  test('malformed percent-encoding: rejects via notFound', async () => {
+    cachedResult = null
+    await expect(generateMetadata(paramsFor('%E0%A4%A'))).rejects.toThrow()
+  })
+})

--- a/bun.lock
+++ b/bun.lock
@@ -11,7 +11,7 @@
         "@vercel/analytics": "^1.6.1",
         "@vercel/speed-insights": "^2.0.0",
         "lucide-react": "^0.563.0",
-        "next": "16.2.3",
+        "next": "16.2.6",
         "react": "19.2.3",
         "react-dom": "19.2.3",
         "zod": "^4.3.6",
@@ -164,25 +164,25 @@
 
     "@napi-rs/wasm-runtime": ["@napi-rs/wasm-runtime@0.2.12", "", { "dependencies": { "@emnapi/core": "^1.4.3", "@emnapi/runtime": "^1.4.3", "@tybys/wasm-util": "^0.10.0" } }, "sha512-ZVWUcfwY4E/yPitQJl481FjFo3K22D6qF0DuFH6Y/nbnE11GY5uguDxZMGXPQ8WQ0128MXQD7TnfHyK4oWoIJQ=="],
 
-    "@next/env": ["@next/env@16.2.3", "", {}, "sha512-ZWXyj4uNu4GCWQw9cjRxWlbD+33mcDszIo9iQxFnBX3Wmgq9ulaSJcl6VhuWx5pCWqqD+9W6Wfz7N0lM5lYPMA=="],
+    "@next/env": ["@next/env@16.2.6", "", {}, "sha512-gd8HoHN4ufj73WmR3JmVolrpJR47ILK6LouP5xElPglaVxir6e1a7VzvTvDWkOoPXT9rkkTzyCxBu4yeZfZwcw=="],
 
     "@next/eslint-plugin-next": ["@next/eslint-plugin-next@16.1.1", "", { "dependencies": { "fast-glob": "3.3.1" } }, "sha512-Ovb/6TuLKbE1UiPcg0p39Ke3puyTCIKN9hGbNItmpQsp+WX3qrjO3WaMVSi6JHr9X1NrmthqIguVHodMJbh/dw=="],
 
-    "@next/swc-darwin-arm64": ["@next/swc-darwin-arm64@16.2.3", "", { "os": "darwin", "cpu": "arm64" }, "sha512-u37KDKTKQ+OQLvY+z7SNXixwo4Q2/IAJFDzU1fYe66IbCE51aDSAzkNDkWmLN0yjTUh4BKBd+hb69jYn6qqqSg=="],
+    "@next/swc-darwin-arm64": ["@next/swc-darwin-arm64@16.2.6", "", { "os": "darwin", "cpu": "arm64" }, "sha512-ZJGkkcNfYgrrMkqOdZ7zoLa1TOy0qpcMfk/z4Mh/FKUz40gVO+HNQWqmLxf67Z5WB64DRp0dhEbyHfel+6sJUg=="],
 
-    "@next/swc-darwin-x64": ["@next/swc-darwin-x64@16.2.3", "", { "os": "darwin", "cpu": "x64" }, "sha512-gHjL/qy6Q6CG3176FWbAKyKh9IfntKZTB3RY/YOJdDFpHGsUDXVH38U4mMNpHVGXmeYW4wj22dMp1lTfmu/bTQ=="],
+    "@next/swc-darwin-x64": ["@next/swc-darwin-x64@16.2.6", "", { "os": "darwin", "cpu": "x64" }, "sha512-v/YLBHIY132Ced3puBJ7YJKw1lqsCrgcNo2aRJlCEyQrrCeRJlvGlnmxhPxNQI3KE3N1DN5r9TPNPvka3nq5RQ=="],
 
-    "@next/swc-linux-arm64-gnu": ["@next/swc-linux-arm64-gnu@16.2.3", "", { "os": "linux", "cpu": "arm64" }, "sha512-U6vtblPtU/P14Y/b/n9ZY0GOxbbIhTFuaFR7F4/uMBidCi2nSdaOFhA0Go81L61Zd6527+yvuX44T4ksnf8T+Q=="],
+    "@next/swc-linux-arm64-gnu": ["@next/swc-linux-arm64-gnu@16.2.6", "", { "os": "linux", "cpu": "arm64" }, "sha512-RPOvqlYBbcQjkz9VQQDZ2T2bARIjXZV1KFlt+V2Mr6SW/e4I9fcKsaA0hdyf2FHoTlsV2xnBd5Y912rP/1Ce6w=="],
 
-    "@next/swc-linux-arm64-musl": ["@next/swc-linux-arm64-musl@16.2.3", "", { "os": "linux", "cpu": "arm64" }, "sha512-/YV0LgjHUmfhQpn9bVoGc4x4nan64pkhWR5wyEV8yCOfwwrH630KpvRg86olQHTwHIn1z59uh6JwKvHq1h4QEw=="],
+    "@next/swc-linux-arm64-musl": ["@next/swc-linux-arm64-musl@16.2.6", "", { "os": "linux", "cpu": "arm64" }, "sha512-URUTu1+dMkxJsPFgm+OeEvq9wf5sujw0EvgYy80TDGHTSLTnIHeqb0Eu8A3sC95IRgjejQL+kC4mw+4yPxiAXA=="],
 
-    "@next/swc-linux-x64-gnu": ["@next/swc-linux-x64-gnu@16.2.3", "", { "os": "linux", "cpu": "x64" }, "sha512-/HiWEcp+WMZ7VajuiMEFGZ6cg0+aYZPqCJD3YJEfpVWQsKYSjXQG06vJP6F1rdA03COD9Fef4aODs3YxKx+RDQ=="],
+    "@next/swc-linux-x64-gnu": ["@next/swc-linux-x64-gnu@16.2.6", "", { "os": "linux", "cpu": "x64" }, "sha512-DOj182mPV8G3UkrayLoREM5YEYI+Dk5wv7Ox9xl1fFibAELEsFD0lDPfHIeILlutMMfdyhlzYPELG3peuKaurw=="],
 
-    "@next/swc-linux-x64-musl": ["@next/swc-linux-x64-musl@16.2.3", "", { "os": "linux", "cpu": "x64" }, "sha512-Kt44hGJfZSefebhk/7nIdivoDr3Ugp5+oNz9VvF3GUtfxutucUIHfIO0ZYO8QlOPDQloUVQn4NVC/9JvHRk9hw=="],
+    "@next/swc-linux-x64-musl": ["@next/swc-linux-x64-musl@16.2.6", "", { "os": "linux", "cpu": "x64" }, "sha512-HKQ5SP/V/ub73UvF7n/zeJlxk2kLmtL7Wzrg4WfmkjmNos5onJ2tKu7yZOPdL18A6Svfn3max29ym+ry7NkK4g=="],
 
-    "@next/swc-win32-arm64-msvc": ["@next/swc-win32-arm64-msvc@16.2.3", "", { "os": "win32", "cpu": "arm64" }, "sha512-O2NZ9ie3Tq6xj5Z5CSwBT3+aWAMW2PIZ4egUi9MaWLkwaehgtB7YZjPm+UpcNpKOme0IQuqDcor7BsW6QBiQBw=="],
+    "@next/swc-win32-arm64-msvc": ["@next/swc-win32-arm64-msvc@16.2.6", "", { "os": "win32", "cpu": "arm64" }, "sha512-LZXpTlPyS5v7HhSmnvsLGP3iIYgYOBnc8r8ArlT55sGHV89bR2HlDdBjWQ+PY6SJMmk8TuVGFuxalnP3k/0Dwg=="],
 
-    "@next/swc-win32-x64-msvc": ["@next/swc-win32-x64-msvc@16.2.3", "", { "os": "win32", "cpu": "x64" }, "sha512-Ibm29/GgB/ab5n7XKqlStkm54qqZE8v2FnijUPBgrd67FWrac45o/RsNlaOWjme/B5UqeWt/8KM4aWBwA1D2Kw=="],
+    "@next/swc-win32-x64-msvc": ["@next/swc-win32-x64-msvc@16.2.6", "", { "os": "win32", "cpu": "x64" }, "sha512-F0+4i0h9J6C4eE3EAPWsoCk7UW/dbzOjyzxY0qnDUOYFu6FFmdZ6l97/XdV3/Nz3VYyO7UWjyEJUXkGqcoXfMA=="],
 
     "@nodelib/fs.scandir": ["@nodelib/fs.scandir@2.1.5", "", { "dependencies": { "@nodelib/fs.stat": "2.0.5", "run-parallel": "^1.1.9" } }, "sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g=="],
 
@@ -714,7 +714,7 @@
 
     "natural-compare": ["natural-compare@1.4.0", "", {}, "sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw=="],
 
-    "next": ["next@16.2.3", "", { "dependencies": { "@next/env": "16.2.3", "@swc/helpers": "0.5.15", "baseline-browser-mapping": "^2.9.19", "caniuse-lite": "^1.0.30001579", "postcss": "8.4.31", "styled-jsx": "5.1.6" }, "optionalDependencies": { "@next/swc-darwin-arm64": "16.2.3", "@next/swc-darwin-x64": "16.2.3", "@next/swc-linux-arm64-gnu": "16.2.3", "@next/swc-linux-arm64-musl": "16.2.3", "@next/swc-linux-x64-gnu": "16.2.3", "@next/swc-linux-x64-musl": "16.2.3", "@next/swc-win32-arm64-msvc": "16.2.3", "@next/swc-win32-x64-msvc": "16.2.3", "sharp": "^0.34.5" }, "peerDependencies": { "@opentelemetry/api": "^1.1.0", "@playwright/test": "^1.51.1", "babel-plugin-react-compiler": "*", "react": "^18.2.0 || 19.0.0-rc-de68d2f4-20241204 || ^19.0.0", "react-dom": "^18.2.0 || 19.0.0-rc-de68d2f4-20241204 || ^19.0.0", "sass": "^1.3.0" }, "optionalPeers": ["@opentelemetry/api", "@playwright/test", "babel-plugin-react-compiler", "sass"], "bin": { "next": "dist/bin/next" } }, "sha512-9V3zV4oZFza3PVev5/poB9g0dEafVcgNyQ8eTRop8GvxZjV2G15FC5ARuG1eFD42QgeYkzJBJzHghNP8Ad9xtA=="],
+    "next": ["next@16.2.6", "", { "dependencies": { "@next/env": "16.2.6", "@swc/helpers": "0.5.15", "baseline-browser-mapping": "^2.9.19", "caniuse-lite": "^1.0.30001579", "postcss": "8.4.31", "styled-jsx": "5.1.6" }, "optionalDependencies": { "@next/swc-darwin-arm64": "16.2.6", "@next/swc-darwin-x64": "16.2.6", "@next/swc-linux-arm64-gnu": "16.2.6", "@next/swc-linux-arm64-musl": "16.2.6", "@next/swc-linux-x64-gnu": "16.2.6", "@next/swc-linux-x64-musl": "16.2.6", "@next/swc-win32-arm64-msvc": "16.2.6", "@next/swc-win32-x64-msvc": "16.2.6", "sharp": "^0.34.5" }, "peerDependencies": { "@opentelemetry/api": "^1.1.0", "@playwright/test": "^1.51.1", "babel-plugin-react-compiler": "*", "react": "^18.2.0 || 19.0.0-rc-de68d2f4-20241204 || ^19.0.0", "react-dom": "^18.2.0 || 19.0.0-rc-de68d2f4-20241204 || ^19.0.0", "sass": "^1.3.0" }, "optionalPeers": ["@opentelemetry/api", "@playwright/test", "babel-plugin-react-compiler", "sass"], "bin": { "next": "dist/bin/next" } }, "sha512-qOVgKJg1+At15NpeUP+eJgCHvTCgXsogweq87Ri/Ix7PkqQHg4sdaXmSFqKlgaIXE4kW0g25LE68W87UANlHtw=="],
 
     "node-releases": ["node-releases@2.0.27", "", {}, "sha512-nmh3lCkYZ3grZvqcCH+fjmQ7X+H0OeZgP40OierEaAptX4XofMh5kwNbWh7lBduUzCcV/8kZ+NDLCwm2iorIlA=="],
 

--- a/bun.lock
+++ b/bun.lock
@@ -18,6 +18,7 @@
       },
       "devDependencies": {
         "@tailwindcss/postcss": "^4.2.2",
+        "@types/bun": "^1.3.14",
         "@types/node": "^20.19.39",
         "@types/react": "^19.2.14",
         "@types/react-dom": "^19.2.3",
@@ -227,6 +228,8 @@
 
     "@tybys/wasm-util": ["@tybys/wasm-util@0.10.1", "", { "dependencies": { "tslib": "^2.4.0" } }, "sha512-9tTaPJLSiejZKx+Bmog4uSubteqTvFrVrURwkmHixBo0G4seD0zUxp98E1DzUBJxLQ3NPwXrGKDiVjwx/DpPsg=="],
 
+    "@types/bun": ["@types/bun@1.3.14", "", { "dependencies": { "bun-types": "1.3.14" } }, "sha512-h1hFqFVcvAvD9j9K7ZW7vd82aSA+rTdznZa+5bwvCwqSB1jmmfLcbIWhOLx1/+boy/xmjgCs/OMUL8hRJSmnPw=="],
+
     "@types/estree": ["@types/estree@1.0.8", "", {}, "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w=="],
 
     "@types/json-schema": ["@types/json-schema@7.0.15", "", {}, "sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA=="],
@@ -358,6 +361,8 @@
     "braces": ["braces@3.0.3", "", { "dependencies": { "fill-range": "^7.1.1" } }, "sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA=="],
 
     "browserslist": ["browserslist@4.28.1", "", { "dependencies": { "baseline-browser-mapping": "^2.9.0", "caniuse-lite": "^1.0.30001759", "electron-to-chromium": "^1.5.263", "node-releases": "^2.0.27", "update-browserslist-db": "^1.2.0" }, "bin": { "browserslist": "cli.js" } }, "sha512-ZC5Bd0LgJXgwGqUknZY/vkUQ04r8NXnJZ3yYi4vDmSiZmC/pdSN0NbNRPxZpbtO4uAfDUAFffO8IZoM3Gj8IkA=="],
+
+    "bun-types": ["bun-types@1.3.14", "", { "dependencies": { "@types/node": "*" } }, "sha512-4N0ig0fEomHt5R0KCFWjovxow98rIoRwKolrYdCcknNwMekCXRnWEUvgu5soYV8QXtVsrUD8B95MBOZGPvr6KQ=="],
 
     "call-bind": ["call-bind@1.0.8", "", { "dependencies": { "call-bind-apply-helpers": "^1.0.0", "es-define-property": "^1.0.0", "get-intrinsic": "^1.2.4", "set-function-length": "^1.2.2" } }, "sha512-oKlSFMcMwpUg2ednkhQ454wfWiU/ul3CkJe/PEHcTKuiX6RpbehUiFMXu13HalGZxfUwCQzZG747YXBn1im9ww=="],
 

--- a/components/ShareMenu.tsx
+++ b/components/ShareMenu.tsx
@@ -26,7 +26,11 @@ export function ShareMenu({ result }: ShareMenuProps) {
 
   const handleCopyLink = async () => {
     try {
-      await navigator.clipboard.writeText(window.location.href)
+      const word = result.word.trim().toLowerCase()
+      const shareUrl = word
+        ? `${window.location.origin}/word/${encodeURIComponent(word)}`
+        : window.location.href
+      await navigator.clipboard.writeText(shareUrl)
       showFeedback()
       setIsOpen(false)
     } catch (err) {

--- a/components/WordPageEntry.tsx
+++ b/components/WordPageEntry.tsx
@@ -1,0 +1,35 @@
+'use client'
+
+import { useCallback } from 'react'
+import { useRouter } from 'next/navigation'
+import { EtymologyCard } from '@/components/EtymologyCard'
+import { ShareMenu } from '@/components/ShareMenu'
+import type { EtymologyResult } from '@/lib/types'
+
+interface WordPageEntryProps {
+  result: EtymologyResult
+}
+
+/**
+ * Client shell for the server-rendered /word/[word] page.
+ * Reuses the EtymologyCard presentation; word clicks route to the live
+ * explorer (/?q=word) so follow-up searches keep the streaming UX.
+ */
+export function WordPageEntry({ result }: WordPageEntryProps) {
+  const router = useRouter()
+
+  const navigateToWord = useCallback(
+    (word: string) => {
+      router.push(`/?q=${encodeURIComponent(word)}`)
+    },
+    [router]
+  )
+
+  return (
+    <EtymologyCard
+      result={result}
+      onWordClick={navigateToWord}
+      headerActions={<ShareMenu result={result} />}
+    />
+  )
+}

--- a/lib/cache.ts
+++ b/lib/cache.ts
@@ -22,8 +22,8 @@ function jitterTTL(ttl: number): number {
 }
 
 // Bump version when EtymologyResult schema or sourcing behavior changes
-const CACHE_VERSION = '2.2'
-const ETYMOLOGY_PREFIX = `etymology:v${CACHE_VERSION}:`
+export const CACHE_VERSION = '2.2'
+export const ETYMOLOGY_PREFIX = `etymology:v${CACHE_VERSION}:`
 const ETYMOLOGY_TTL = CONFIG.etymologyCacheTTL
 
 // Audio cache (longer TTL - pronunciations don't change)

--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
   },
   "devDependencies": {
     "@tailwindcss/postcss": "^4.2.2",
+    "@types/bun": "^1.3.14",
     "@types/node": "^20.19.39",
     "@types/react": "^19.2.14",
     "@types/react-dom": "^19.2.3",


### PR DESCRIPTION
## What

Adds SEO word pages that are served strictly from the Redis cache — crawler traffic can never trigger LLM spend.

- **`app/word/[word]/page.tsx`**: SSR from `getCachedEtymology` only (ISR, `revalidate = 86400`). Cache hit reuses `EtymologyCard` via a thin client shell (`components/WordPageEntry.tsx`); cache miss renders a noindex page with a "Trace it live" CTA to `/?q={word}`; invalid words 404 (`canonicalizeWord` + `isValidWord`). Redis reads are wrapped in `unstable_cache` because the Upstash client issues no-store fetches, which otherwise flip the ISR route to dynamic at runtime (`app-static-to-dynamic-error`, observed as 500s under `next start`).
- **Per-word metadata**: title `Etymology of {word} — EtymEx`, description from definition + lore (truncated ~155 chars at a word boundary), canonical `/word/{word}`, OG/Twitter images via `/og?word={word}`.
- **`app/og/route.tsx`**: accepts `?word=` and renders a per-word card (Libre Baskerville italic, accent initial, cream/charcoal); falls back to the brand card for absent/invalid words.
- **`app/sitemap.ts`**: cursor-paginated `SCAN` over cached etymology keys (capped at 1000), using the now-exported `ETYMOLOGY_PREFIX`/`CACHE_VERSION` from `lib/cache.ts` (the only cache.ts change). Fails open to the static entries; the word list revalidates daily.
- **Canonicals**: `/?q=word` sets canonical `/word/{word}` via `generateMetadata` (bare `/` keeps `/`); `ShareMenu` copies `/word/{word}` links. Client search UX stays on `/?q=`.
- **Tests (bun:test)**: metadata generation for hit/miss/invalid/malformed-encoding/canonicalization, and an import-graph test that statically walks the transitive imports of the word page and asserts `lib/research.ts`, `lib/llm.ts`, and `lib/openrouterResponses.ts` are absent (mutation-checked: injecting an `import '@/lib/llm'` fails the test).
- `@types/bun` added so `tsc --noEmit` passes on the existing and new `bun:test` files.

## Verification

- `bun test`: 26 pass, 0 fail
- `bun run lint`, `prettier --check`, `bunx tsc --noEmit`: clean
- `bun run build`: green — `● /word/[word]` (ISR), `○ /sitemap.xml` (revalidate 1d)
- `bun run build && bun run start` against production Redis (359 cached words):
  - `/word/ability` → 200, `robots index,follow`, canonical `https://etymex.com/word/ability`, `og:image /og?word=ability`, full server-rendered entry; second hit `x-nextjs-cache: HIT`
  - `/word/zymurgology` (uncached) → noindex + "Trace it live" CTA to `/?q=zymurgology`
  - `/word/not%20a%20word%21%21` → 404
  - `/sitemap.xml` → 362 URLs (3 static + 359 `/word/*`)
  - `/?q=nice` → canonical `/word/nice`; bare `/` → canonical `/`
  - `/og?word=perfidious` → per-word card; `/og` → brand card

Merge order: independent — mergeable whenever green. Expected conflicts: lib/cache.ts (trivial export) with fix/safety-hardening.

https://claude.ai/code/session_012GTdDDmz56DHGedvS2suof

## Note on dependency pins (main-merge maintenance)

This branch is merged up to main (includes #67 safety hardening, #68, #69). The #69 group bump broke main's own Lint and Test/Typecheck jobs with two premature majors, so the merge commit pins them back (same pins as #70; they dedupe cleanly when #70 lands):

- `eslint` 10.6.0 → `^9.39.4` — eslint-plugin-react 7.37.5 (bundled by eslint-config-next) supports eslint ≤9 only; crashes on removed `context.getFilename`
- `typescript` 6.0.3 → `^5.9.3` — TS 6 no longer resolves `@types/bun`'s `/// <reference types="bun-types" />`, so `bun:test` typings vanish

Review-fix commit 5f42f2d additionally addresses all Codex/Gemini bot comments (see resolved threads).
