### PR TITLE
fix: safety hardening — singleflight, cost guard, fail-closed Redis, page CSP

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -18,6 +18,8 @@ ADMIN_SECRET=
 # ===========================================
 # Create a free Redis database at https://upstash.com
 # Enables: result caching, rate limiting, and monthly budget enforcement
+# Note: without Redis, uncached /api/etymology searches return 503 (fail
+# closed — no budget enforcement or deduplication is possible without it)
 ETYMOLOGY_KV_REST_API_URL=
 ETYMOLOGY_KV_REST_API_TOKEN=
 
@@ -36,3 +38,5 @@ ELEVENLABS_VOICE_ID=
 # PUBLIC_SEARCH_ENABLED=true
 # PRONUNCIATION_ENABLED=true
 # FORCE_CACHE_ONLY=false
+# Set to false to disable per-IP rate limiting (e.g. for local load testing)
+# RATE_LIMIT_ENABLED=true

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -43,11 +43,11 @@ Pre-commit hooks (Husky + lint-staged) automatically run ESLint and Prettier on 
 ```
 User Search → proxy.ts (rate limit, CSP headers)
     ↓
-GET /api/etymology?word=X[&stream=true]
+GET /api/etymology?word=X[&stream=true]   (maxDuration 300s)
     ├── Input validation (lib/validation.ts)
     ├── Redis cache check (lib/cache.ts, 30d TTL)
-    ├── Singleflight lock (lib/singleflight.ts, prevents duplicate concurrent requests)
-    ├── Cost guard check (lib/costGuard.ts, 4 modes: normal → protected_503 → cache_only → blocked)
+    ├── Cost guard check (lib/costGuard.ts, 2 modes: normal → cache_only at 90% of budget)
+    ├── Singleflight lock (lib/singleflight.ts, owner-token lock; Redis down → 503 for uncached)
     ├── Agentic Research Pipeline (lib/research.ts):
     │   ├── Phase 1: Parallel fetch from 6 sources (3 core + 3 optional)
     │   ├── Phase 1.5: Pre-parse "from X, from Y" chains (lib/etymologyParser.ts, CPU-only)
@@ -67,36 +67,38 @@ GET /api/etymology?word=X[&stream=true]
 
 The app operates in **public mode** with server-side cost controls (added in PR #41):
 
-- **`proxy.ts`** - Rate limiting via @upstash/ratelimit:
+- **`proxy.ts`** - Node middleware for rate limiting via @upstash/ratelimit:
   - Etymology: 20 req/min + 200 req/day per IP
   - Pronunciation: 20 req/min per IP
   - General: 60 req/min per IP
-  - CSP headers and security headers
+  - CSP headers for pages and API responses (pages use `script-src 'self' 'unsafe-inline'` because statically prerendered HTML carries per-build Next.js inline flight scripts that can't be hashed or nonce'd)
 
 - **`lib/config.ts`** - Centralized configuration:
   - Per-IP rate caps: etymology 20/min + 200/day, pronunciation 20/min, general 60/min
-  - USD monthly limit: $10/month (`openai/gpt-5.4-mini` pricing in `costTracking`)
+  - USD monthly limit: $10/month (`openai/gpt-5.4-mini` pricing in `costTracking` as fallback; OpenRouter-reported cost preferred)
   - Timeouts: source fetches 5s, LLM 120s, TTS 8s
   - Rate limits, singleflight settings, feature flags
 
 - **`lib/env.ts`** - Zod-based env validation with lazy init (build-time safe). Validates OPENROUTER_API_KEY, ADMIN_SECRET, Redis credentials, ElevenLabs config.
 
-- **`lib/costGuard.ts`** - Monthly USD budget enforcement via atomic Redis accumulation:
-  - Normal mode (0-70% budget): allow uncached requests
-  - Protected_503 mode (70-90%): reject uncached requests
-  - Cache-only mode (90-100%): serve cached results only
-  - Blocked mode (100%+): reject new requests
-  - Fail-open if Redis unavailable
+- **`lib/costGuard.ts`** - Monthly USD budget enforcement via pipelined Redis INCRBYFLOAT + EXPIRE NX:
+  - Normal mode (0-90% of budget): allow uncached requests
+  - Cache-only mode (≥90%): serve cached results only, reject uncached requests
+  - Spend recording is awaited before responses finish; both the root-extraction and synthesis LLM calls are counted
+  - Prefers OpenRouter provider-reported cost (`usage.cost`) with config-pricing math as fallback
+  - The guard itself fails open without Redis, but uncached etymology requests fail closed (503) at the singleflight step
 
-- **`lib/singleflight.ts`** - Distributed request deduplication via Redis SET NX (30s TTL). If 10 users search "etymology" simultaneously, only 1 LLM call is made; others poll and receive the same result.
+- **`lib/singleflight.ts`** - Distributed request deduplication via Redis owner-token locks (SET NX with random token, 90s TTL, EXPIRE heartbeat every 30s while the pipeline runs). Results are cached BEFORE lock release. Streaming waiters poll the cache every 2s for up to 150s with SSE keepalive events and negative-cache checks, and promote themselves to holder if the lock vanishes without a result; non-streaming waiters poll ~10s then return 429 + Retry-After. If 10 users search "etymology" simultaneously, only 1 LLM call is made.
 
-- **`lib/cache.ts`** - Redis caching:
-  - Etymology results: 30 day TTL, versioned keys (`etymology:v2.1:`)
+- **`lib/cache.ts`** - Redis caching (via the shared `getRedis()` factory):
+  - Etymology results: 30 day TTL, versioned keys (`etymology:v2.2:`)
   - TTS audio: 1 year TTL
   - Negative cache: 6 hour TTL for admitted types (`no_sources`, `invalid_word`)
   - Zod validation on reads for forward compatibility
 
-- **`lib/redis.ts`** - Shared Redis client factory (returns null if not configured; all callers fail open)
+- **`lib/redis.ts`** - Shared Redis client factory (returns null if not configured). Most callers fail open; uncached etymology fails closed with 503 (suggestions, random-word, and pronunciation keep working without Redis)
+
+- **`lib/counters.ts`** - Best-effort monthly INCR counters (cache_hit / cache_miss / error), exposed via `/api/admin/stats`
 
 - **`lib/errorUtils.ts`** - Secret redaction (provider keys, Bearer tokens, API keys)
 
@@ -155,8 +157,8 @@ LLM receives:
 - Cached etymology results (30d TTL)
 - TTS audio cache (1yr TTL)
 - Rate limit counters (per-IP, sliding windows)
-- Monthly spend counters (atomic accumulation)
-- Singleflight locks (30s TTL)
+- Monthly spend counters (atomic accumulation) + operational counters (cache_hit/miss/error)
+- Singleflight owner-token locks (90s TTL, heartbeat-extended while work runs)
 - Negative cache for admitted invalid/no-source words (6hr TTL)
 
 **Client-side** (localStorage):
@@ -211,7 +213,9 @@ When adding UI: _"Would this feel at home in a beautifully typeset etymology dic
 | `/api/suggestions`   | GET    | Typo correction - `?q=word`                                                       |
 | `/api/random-word`   | GET    | Random GRE word (crypto randomness)                                               |
 | `/api/pronunciation` | GET    | TTS audio - `?word=word` (ElevenLabs, 8s timeout)                                 |
-| `/api/admin/stats`   | GET    | Budget usage stats (requires `x-admin-secret` header)                             |
+| `/api/ngram`         | GET    | Google Books ngram usage data - `?word=word`                                      |
+| `/api/health`        | GET    | Liveness check                                                                    |
+| `/api/admin/stats`   | GET    | Budget + counter stats (requires `x-admin-secret` header)                         |
 
 All return `{ success: boolean, data?: T, error?: string }` wrapper.
 
@@ -222,10 +226,11 @@ All return `{ success: boolean, data?: T, error?: string }` wrapper.
 - `proxy.ts` - Rate limiting, CSP headers
 - `lib/config.ts` - Centralized config (budgets, timeouts, limits)
 - `lib/env.ts` - Zod env validation
-- `lib/costGuard.ts` - Monthly spend enforcement with protection modes
-- `lib/singleflight.ts` - Distributed request deduplication
+- `lib/costGuard.ts` - Monthly spend enforcement (normal → cache_only at 90%)
+- `lib/singleflight.ts` - Distributed request deduplication (owner-token locks)
 - `lib/cache.ts` - Redis caching with versioned keys
 - `lib/redis.ts` - Shared Redis client factory
+- `lib/counters.ts` - Monthly cache_hit/cache_miss/error counters for admin stats
 
 **Grounded Etymology:**
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -88,7 +88,7 @@ The app operates in **public mode** with server-side cost controls (added in PR 
   - Prefers OpenRouter provider-reported cost (`usage.cost`) with config-pricing math as fallback
   - The guard itself fails open without Redis, but uncached etymology requests fail closed (503) at the singleflight step
 
-- **`lib/singleflight.ts`** - Distributed request deduplication via Redis owner-token locks (SET NX with random token, 90s TTL, EXPIRE heartbeat every 30s while the pipeline runs). Results are cached BEFORE lock release. Streaming waiters poll the cache every 2s for up to 150s with SSE keepalive events and negative-cache checks, and promote themselves to holder if the lock vanishes without a result; non-streaming waiters poll ~10s then return 429 + Retry-After. If 10 users search "etymology" simultaneously, only 1 LLM call is made.
+- **`lib/singleflight.ts`** - Distributed request deduplication via Redis owner-token locks (SET NX with random token, 90s TTL, EXPIRE heartbeat every 30s while the pipeline runs). Results are cached BEFORE lock release. Streaming waiters poll the cache every 2s for up to 150s with SSE keepalive events and negative-cache checks; non-streaming waiters poll ~10s then return 429 + Retry-After. A holder that errors writes a short-TTL failure marker (60s) before releasing, so waiters surface the error; promotion to holder only happens on a true crash — lock vanished with neither a result nor a marker. If 10 users search "etymology" simultaneously, only 1 LLM call is made.
 
 - **`lib/cache.ts`** - Redis caching (via the shared `getRedis()` factory):
   - Etymology results: 30 day TTL, versioned keys (`etymology:v2.2:`)

--- a/README.md
+++ b/README.md
@@ -187,13 +187,15 @@ etymology-explorer/
 | `/api/pronunciation` | GET    | Get pronunciation audio                                       | No                |
 | `/api/suggestions`   | GET    | Get typo correction suggestions                               | No                |
 | `/api/random-word`   | GET    | Get a random word                                             | No                |
-| `/api/admin/stats`   | GET    | Get budget/usage statistics                                   | Admin secret      |
+| `/api/ngram`         | GET    | Get Google Books usage-over-time data (`?word=X`)             | No                |
+| `/api/health`        | GET    | Liveness check                                                | No                |
+| `/api/admin/stats`   | GET    | Get budget/usage statistics and counters                      | Admin secret      |
 
 ## How It Works
 
-1. **Request Deduplication**: Singleflight mechanism prevents duplicate concurrent searches
+1. **Request Deduplication**: Singleflight owner-token locks (90s TTL, heartbeat-extended) ensure one pipeline run per word; waiters poll the cache for the holder's result, and streaming waiters can take over if the holder crashes
 2. **Rate Limiting**: Per-IP rate limiting (20 req/min + 200 req/day) via Upstash Redis
-3. **Cache Check**: Redis cache lookup with versioned keys (`etymology:v2.1:`), schema validation on read, and negative cache (6h) for known no-source/invalid words
+3. **Cache Check**: Redis cache lookup with versioned keys (`etymology:v2.2:`), schema validation on read, and negative cache (6h) for known no-source/invalid words. Without Redis, uncached searches return 503 (fail closed)
 4. **Grounded Etymology Pipeline**:
    - **Parser** (CPU-only): Extracts "from X, from Y" chains from raw source text
    - **Agentic Research**: Multi-phase research pipeline:
@@ -205,7 +207,7 @@ etymology-explorer/
    - **LLM Synthesis**: Aggregated research context sent to LLM with structured output schema
    - **Enricher** (CPU): Post-processes LLM output, assigns confidence scores (high/medium/low) based on source evidence match
 5. **Guaranteed JSON**: Using constrained decoding, the LLM produces valid JSON matching the exact schema
-6. **Budget Enforcement**: Cost guard tracks monthly spend and enforces protection modes (normal → protected_503 → cache_only → blocked) against a $10/month cap using `openai/gpt-5.4-mini` pricing
+6. **Budget Enforcement**: Cost guard tracks monthly spend (OpenRouter-reported cost, with `openai/gpt-5.4-mini` pricing as fallback) against a $10/month cap and switches from normal to cache_only mode at 90% of budget; both the root-extraction and synthesis LLM calls are counted
 7. **Rich Display**: Etymology rendered with expandable roots, ancestry graph with confidence badges, POS tags, modern usage, related words, and source attribution (supplemental sources are only surfaced when significance checks pass)
 
 ### Architecture Diagram
@@ -218,15 +220,15 @@ etymology-explorer/
                │ GET /api/etymology?word=X[&stream=true]
                ▼
 ┌──────────────────────────────────────────────────────────────────────────────┐
-│ Edge + Route Entry                                                           │
+│ Middleware (Node) + Route Entry                                              │
 │ proxy.ts: rate limit + CSP   →   app/api/etymology/route.ts: validate input  │
 └──────────────────────────────┬───────────────────────────────────────────────┘
                                ▼
 ┌──────────────────────────────────────────────────────────────────────────────┐
 │ Control Plane                                                                │
 │ cache hit? → return cached result                                            │
-│ singleflight lock → dedupe concurrent lookups                                │
-│ cost guard → normal | protected_503 | cache_only | blocked                  │
+│ cost guard → normal | cache_only (at 90% of monthly budget)                 │
+│ singleflight lock → dedupe concurrent lookups (Redis down → 503 uncached)   │
 └──────────────────────────────┬───────────────────────────────────────────────┘
                                │ cache miss
                                ▼

--- a/app/api/admin/stats/route.ts
+++ b/app/api/admin/stats/route.ts
@@ -1,10 +1,21 @@
 import { NextRequest, NextResponse } from 'next/server'
 import { timingSafeEqual } from 'crypto'
 import { getSpendStats } from '@/lib/costGuard'
+import { getCounters } from '@/lib/counters'
+import { getEnv } from '@/lib/env'
 
 export async function GET(request: NextRequest) {
+  let adminSecret: string | undefined
+  try {
+    adminSecret = getEnv().ADMIN_SECRET
+  } catch {
+    return NextResponse.json(
+      { success: false, error: 'Service configuration error' },
+      { status: 503 }
+    )
+  }
+
   const secret = request.headers.get('x-admin-secret')
-  const adminSecret = process.env.ADMIN_SECRET
 
   // Timing-safe comparison prevents timing attacks on the secret
   const authorized =
@@ -17,7 +28,7 @@ export async function GET(request: NextRequest) {
     return NextResponse.json({ success: false, error: 'Unauthorized' }, { status: 401 })
   }
 
-  const spend = await getSpendStats()
+  const [spend, counters] = await Promise.all([getSpendStats(), getCounters()])
 
   if (!spend) {
     return NextResponse.json(
@@ -31,6 +42,7 @@ export async function GET(request: NextRequest) {
     data: {
       month: spend.period,
       spend,
+      counters,
     },
   })
 }

--- a/app/api/admin/stats/route.ts
+++ b/app/api/admin/stats/route.ts
@@ -1,8 +1,12 @@
 import { NextRequest, NextResponse } from 'next/server'
-import { timingSafeEqual } from 'crypto'
+import { createHash, timingSafeEqual } from 'crypto'
 import { getSpendStats } from '@/lib/costGuard'
 import { getCounters } from '@/lib/counters'
 import { getEnv } from '@/lib/env'
+
+function sha256(value: string): Buffer {
+  return createHash('sha256').update(value).digest()
+}
 
 export async function GET(request: NextRequest) {
   let adminSecret: string | undefined
@@ -17,12 +21,10 @@ export async function GET(request: NextRequest) {
 
   const secret = request.headers.get('x-admin-secret')
 
-  // Timing-safe comparison prevents timing attacks on the secret
+  // Compare fixed-length digests: timingSafeEqual stays timing-safe and no
+  // length precheck is needed, so the secret's length can't leak via timing.
   const authorized =
-    !!adminSecret &&
-    !!secret &&
-    Buffer.byteLength(adminSecret) === Buffer.byteLength(secret) &&
-    timingSafeEqual(Buffer.from(adminSecret), Buffer.from(secret))
+    !!adminSecret && !!secret && timingSafeEqual(sha256(adminSecret), sha256(secret))
 
   if (!authorized) {
     return NextResponse.json({ success: false, error: 'Unauthorized' }, { status: 401 })

--- a/app/api/etymology/route.ts
+++ b/app/api/etymology/route.ts
@@ -18,7 +18,8 @@ import {
   tryAcquireLock,
   releaseLock,
   startLockHeartbeat,
-  isLockHeld,
+  markLockFailure,
+  attemptPromotion,
   pollForResult,
 } from '@/lib/singleflight'
 import { incrCounter } from '@/lib/counters'
@@ -62,7 +63,11 @@ type PipelineOutcome =
   | { kind: 'result'; result: EtymologyResult }
   | { kind: 'no_sources'; typoSuggestions?: string[]; fallbackSuggestion?: string }
 
-type WaiterOutcome = PipelineOutcome | { kind: 'negative_cached' } | { kind: 'timeout' }
+type WaiterOutcome =
+  | PipelineOutcome
+  | { kind: 'negative_cached' }
+  | { kind: 'holder_failed'; message: string }
+  | { kind: 'timeout' }
 
 export async function GET(request: NextRequest) {
   let shouldStream = false
@@ -133,7 +138,7 @@ export async function GET(request: NextRequest) {
         timestamp: Date.now(),
         detail: { word: normalizedWord },
       })
-      void incrCounter('cache_hit')
+      await incrCounter('cache_hit')
       return shouldStream
         ? streamResultResponse(cached, { 'X-Protection-Mode': costMode })
         : NextResponse.json<ApiResponse<EtymologyResult> & { cached: boolean }>(
@@ -212,9 +217,9 @@ export async function GET(request: NextRequest) {
       const researchContext = await conductAgenticResearch(normalizedWord, {}, onProgress)
 
       if (!researchContext.mainWord.etymonline && !researchContext.mainWord.wiktionary) {
-        cacheNegative(normalizedWord, 'no_sources').catch((err) => {
-          console.error('[Etymology API] Negative cache store failed:', safeError(err))
-        })
+        // Awaited so the entry lands BEFORE the lock releases — waiters
+        // poll the negative cache to learn this word has no sources.
+        await cacheNegative(normalizedWord, 'no_sources')
 
         if (isLikelyTypo(normalizedWord)) {
           return {
@@ -240,7 +245,9 @@ export async function GET(request: NextRequest) {
      * Full holder pipeline: heartbeat the lock while working, record spend
      * (awaited) for both the root-extraction and synthesis calls, and write
      * the result to cache BEFORE the lock is released in `finally` so
-     * waiters polling the cache always find it.
+     * waiters polling the cache always find it. On error, a short-TTL
+     * failure marker is written (also before release) so waiters surface
+     * the failure instead of promoting and re-spending.
      */
     const runHolderPipeline = async (
       lockToken: string,
@@ -276,20 +283,28 @@ export async function GET(request: NextRequest) {
           timestamp: Date.now(),
           detail: { word: normalizedWord, sources: researchContext.totalSourcesFetched },
         })
-        void incrCounter('cache_miss')
+        await incrCounter('cache_miss')
 
         return { kind: 'result', result: synthesis.result }
+      } catch (error) {
+        // Distinguish "holder failed" from "holder crashed" for waiters:
+        // written before the lock release below, checked before promotion.
+        await markLockFailure(lockKey, classifyApiError(error).message)
+        throw error
       } finally {
         stopHeartbeat()
-        releaseLock(lockKey, lockToken).catch(() => {})
+        await releaseLock(lockKey, lockToken)
       }
     }
 
     /**
      * Streaming waiter: poll the cache while the holder works, emitting
-     * keepalive events so the SSE connection stays warm. If the lock
-     * vanishes without a cached result (holder crashed), attempt promotion
-     * and run the pipeline ourselves.
+     * keepalive events so the SSE connection stays warm. Promotion only
+     * happens on a true holder crash — a lock that vanished with neither a
+     * cached result nor a failure marker. Failed holders (LLM error etc.)
+     * leave a marker, and waiters surface that error without re-running
+     * the pipeline; a promoted waiter that fails writes the marker too,
+     * so later waiters can't cascade into further promotions.
      */
     const waitAsStreamingWaiter = async (
       emit: (event: StreamEvent) => void
@@ -310,14 +325,15 @@ export async function GET(request: NextRequest) {
           return { kind: 'negative_cached' }
         }
 
-        if (!(await isLockHeld(lockKey))) {
-          const promotion = await tryAcquireLock(lockKey)
-          if (promotion.status === 'acquired') {
-            console.log(`[Etymology API] Promoted waiter to holder for "${normalizedWord}"`)
-            return runHolderPipeline(promotion.token, emit)
-          }
-          // Another waiter won the promotion race — keep polling.
+        const promotion = await attemptPromotion(lockKey)
+        if (promotion.status === 'holder_failed') {
+          return { kind: 'holder_failed', message: promotion.message }
         }
+        if (promotion.status === 'promoted') {
+          console.log(`[Etymology API] Promoted waiter to holder for "${normalizedWord}"`)
+          return runHolderPipeline(promotion.token, emit)
+        }
+        // 'held': holder still working (or another waiter won) — keep polling.
 
         emit({ type: 'singleflight_wait', waitedMs: Date.now() - startedAt })
       }
@@ -372,6 +388,12 @@ export async function GET(request: NextRequest) {
                 message: getQuirkyMessage('nonsense'),
                 errorType: 'nonsense',
               })
+            } else if (outcome.kind === 'holder_failed') {
+              emit({
+                type: 'error',
+                message: outcome.message,
+                errorType: 'unknown',
+              })
             } else {
               emit({
                 type: 'error',
@@ -381,7 +403,7 @@ export async function GET(request: NextRequest) {
             }
           } catch (error) {
             console.error('[Etymology API] Streaming error:', safeError(error))
-            void incrCounter('error')
+            await incrCounter('error')
             const classified = classifyApiError(error)
             emit({
               type: 'error',
@@ -454,7 +476,7 @@ export async function GET(request: NextRequest) {
     )
   } catch (error) {
     console.error('Etymology API error:', safeError(error))
-    void incrCounter('error')
+    await incrCounter('error')
     const classified = classifyApiError(error)
 
     return shouldStream

--- a/app/api/etymology/route.ts
+++ b/app/api/etymology/route.ts
@@ -6,7 +6,7 @@ import {
   StageConfidence,
   ResearchContext,
 } from '@/lib/types'
-import { synthesizeFromResearch, streamSynthesis } from '@/lib/llm'
+import { synthesizeFromResearch, streamSynthesis, SynthesisResult } from '@/lib/llm'
 import { conductAgenticResearch } from '@/lib/research'
 import { isLikelyTypo, getSuggestions } from '@/lib/spellcheck'
 import { getRandomWord } from '@/lib/wordlist'
@@ -14,13 +14,33 @@ import { getQuirkyMessage } from '@/lib/prompts'
 import { getCachedEtymology, cacheEtymology, getNegativeCache, cacheNegative } from '@/lib/cache'
 import { isValidWord, canonicalizeWord } from '@/lib/validation'
 import { getCostMode, recordSpend } from '@/lib/costGuard'
-import { tryAcquireLock, releaseLock, pollForResult } from '@/lib/singleflight'
+import {
+  tryAcquireLock,
+  releaseLock,
+  startLockHeartbeat,
+  isLockHeld,
+  pollForResult,
+} from '@/lib/singleflight'
+import { incrCounter } from '@/lib/counters'
 import { safeError } from '@/lib/errorUtils'
 import { getEnv } from '@/lib/env'
 import { CONFIG } from '@/lib/config'
 import { emitSecurityEvent } from '@/lib/telemetry'
 import { streamErrorResponse, streamResultResponse } from '@/lib/streamingResponse'
 import { classifyApiError } from '@/lib/apiError'
+
+// Uncached searches run a multi-phase research + synthesis pipeline that can
+// take minutes; without this the function dies at the platform default.
+export const maxDuration = 300
+
+const REDIS_DOWN_MESSAGE =
+  'New word lookups are temporarily unavailable — our cache service is unreachable. ' +
+  'Please try again in a few minutes.'
+const IN_PROGRESS_MESSAGE = 'Request in progress, please retry in a few seconds.'
+
+const CACHED_RESPONSE_HEADERS = {
+  'Cache-Control': 'public, s-maxage=86400, stale-while-revalidate=604800',
+} as const
 
 function countConfidence(result: EtymologyResult, level: StageConfidence): number {
   const allStages = [
@@ -29,6 +49,20 @@ function countConfidence(result: EtymologyResult, level: StageConfidence): numbe
   ]
   return allStages.filter((stage) => stage.confidence === level).length
 }
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms))
+}
+
+type ResearchOutcome =
+  | { kind: 'ok'; researchContext: ResearchContext }
+  | { kind: 'no_sources'; typoSuggestions?: string[]; fallbackSuggestion?: string }
+
+type PipelineOutcome =
+  | { kind: 'result'; result: EtymologyResult }
+  | { kind: 'no_sources'; typoSuggestions?: string[]; fallbackSuggestion?: string }
+
+type WaiterOutcome = PipelineOutcome | { kind: 'negative_cached' } | { kind: 'timeout' }
 
 export async function GET(request: NextRequest) {
   let shouldStream = false
@@ -99,13 +133,14 @@ export async function GET(request: NextRequest) {
         timestamp: Date.now(),
         detail: { word: normalizedWord },
       })
+      void incrCounter('cache_hit')
       return shouldStream
         ? streamResultResponse(cached, { 'X-Protection-Mode': costMode })
         : NextResponse.json<ApiResponse<EtymologyResult> & { cached: boolean }>(
             { success: true, data: cached, cached: true },
             {
               headers: {
-                'Cache-Control': 'public, s-maxage=86400, stale-while-revalidate=604800',
+                ...CACHED_RESPONSE_HEADERS,
                 'X-Protection-Mode': costMode,
               },
             }
@@ -154,208 +189,272 @@ export async function GET(request: NextRequest) {
 
     // Singleflight: prevent duplicate LLM calls for the same word
     const lockKey = `lock:etymology:${normalizedWord}`
-    const acquiredLock = await tryAcquireLock(lockKey)
+    const acquisition = await tryAcquireLock(lockKey)
 
-    if (!acquiredLock) {
-      // Another request is already processing this word — poll for its result
-      console.log(`[Etymology API] Waiting for in-flight result for "${normalizedWord}"`)
-      const result = await pollForResult(() => getCachedEtymology(normalizedWord))
-      if (result) {
-        return shouldStream
-          ? streamResultResponse(result)
-          : NextResponse.json<ApiResponse<EtymologyResult> & { cached: boolean }>(
-              { success: true, data: result, cached: true },
-              {
-                headers: {
-                  'Cache-Control': 'public, s-maxage=86400, stale-while-revalidate=604800',
-                },
-              }
-            )
-      }
-      // Timed out waiting — tell client to retry
+    // Fail closed: an uncached synthesis without Redis would run with no
+    // budget enforcement, no dedup, and no caching — reject it instead.
+    // Cached lookups can't exist without Redis, so only uncached paths hit this.
+    if (acquisition.status === 'unavailable' || acquisition.status === 'error') {
+      console.error(
+        `[Etymology API] Redis ${acquisition.status} — failing closed for uncached search`
+      )
       return shouldStream
-        ? streamErrorResponse('Request in progress, please retry in a few seconds.', 'rate_limit')
+        ? streamErrorResponse(REDIS_DOWN_MESSAGE, 'network')
         : NextResponse.json<ApiResponse<null>>(
-            { success: false, error: 'Request in progress, please retry in a few seconds.' },
-            { status: 429, headers: { 'Retry-After': '2' } }
+            { success: false, error: REDIS_DOWN_MESSAGE },
+            { status: 503, headers: { 'Retry-After': '60' } }
           )
     }
 
-    try {
-      const runResearch = async (
-        onProgress?: (event: StreamEvent) => void
-      ): Promise<
-        | { kind: 'ok'; researchContext: ResearchContext }
-        | { kind: 'no_sources'; typoSuggestions?: string[]; fallbackSuggestion?: string }
-      > => {
-        const researchContext = await conductAgenticResearch(normalizedWord, {}, onProgress)
+    const runResearch = async (
+      onProgress?: (event: StreamEvent) => void
+    ): Promise<ResearchOutcome> => {
+      const researchContext = await conductAgenticResearch(normalizedWord, {}, onProgress)
 
-        if (!researchContext.mainWord.etymonline && !researchContext.mainWord.wiktionary) {
-          cacheNegative(normalizedWord, 'no_sources').catch((err) => {
-            console.error('[Etymology API] Negative cache store failed:', safeError(err))
-          })
+      if (!researchContext.mainWord.etymonline && !researchContext.mainWord.wiktionary) {
+        cacheNegative(normalizedWord, 'no_sources').catch((err) => {
+          console.error('[Etymology API] Negative cache store failed:', safeError(err))
+        })
 
-          if (isLikelyTypo(normalizedWord)) {
-            return {
-              kind: 'no_sources',
-              typoSuggestions: getSuggestions(normalizedWord).map((s) => s.word),
-            }
-          }
-
+        if (isLikelyTypo(normalizedWord)) {
           return {
             kind: 'no_sources',
-            fallbackSuggestion: getRandomWord(),
+            typoSuggestions: getSuggestions(normalizedWord).map((s) => s.word),
           }
         }
 
-        console.log(
-          `[Etymology API] Research complete. Fetched ${researchContext.totalSourcesFetched} sources, ` +
-            `identified ${researchContext.identifiedRoots.length} roots`
-        )
-        return { kind: 'ok', researchContext }
+        return {
+          kind: 'no_sources',
+          fallbackSuggestion: getRandomWord(),
+        }
       }
 
-      const recordUsage = (usage: { inputTokens: number; outputTokens: number }) => {
-        recordSpend(usage).catch((err) => {
-          console.error('[Etymology API] Spend recording failed:', safeError(err))
-        })
-      }
+      console.log(
+        `[Etymology API] Research complete. Fetched ${researchContext.totalSourcesFetched} sources, ` +
+          `identified ${researchContext.identifiedRoots.length} roots`
+      )
+      return { kind: 'ok', researchContext }
+    }
 
-      const cacheAndAudit = (researchContext: ResearchContext, result: EtymologyResult) => {
-        cacheEtymology(normalizedWord, result).catch((err) => {
-          console.error('[Etymology API] Cache store failed:', safeError(err))
-        })
+    /**
+     * Full holder pipeline: heartbeat the lock while working, record spend
+     * (awaited) for both the root-extraction and synthesis calls, and write
+     * the result to cache BEFORE the lock is released in `finally` so
+     * waiters polling the cache always find it.
+     */
+    const runHolderPipeline = async (
+      lockToken: string,
+      emit?: (event: StreamEvent) => void
+    ): Promise<PipelineOutcome> => {
+      const stopHeartbeat = startLockHeartbeat(lockKey, lockToken)
+      try {
+        const research = await runResearch(emit)
+        if (research.kind === 'no_sources') {
+          return research
+        }
+        const researchContext = research.researchContext
 
+        if (researchContext.llmUsage) {
+          await recordSpend(researchContext.llmUsage)
+        }
+
+        let synthesis: SynthesisResult
+        if (emit) {
+          emit({ type: 'synthesis_started' })
+          synthesis = await streamSynthesis(researchContext, (token) => {
+            emit({ type: 'synthesis_token', token })
+          })
+        } else {
+          synthesis = await synthesizeFromResearch(researchContext)
+        }
+
+        await recordSpend(synthesis.usage)
+
+        await cacheEtymology(normalizedWord, synthesis.result)
         emitSecurityEvent({
           type: 'cache_miss',
           timestamp: Date.now(),
           detail: { word: normalizedWord, sources: researchContext.totalSourcesFetched },
         })
+        void incrCounter('cache_miss')
+
+        return { kind: 'result', result: synthesis.result }
+      } finally {
+        stopHeartbeat()
+        releaseLock(lockKey, lockToken).catch(() => {})
+      }
+    }
+
+    /**
+     * Streaming waiter: poll the cache while the holder works, emitting
+     * keepalive events so the SSE connection stays warm. If the lock
+     * vanishes without a cached result (holder crashed), attempt promotion
+     * and run the pipeline ourselves.
+     */
+    const waitAsStreamingWaiter = async (
+      emit: (event: StreamEvent) => void
+    ): Promise<WaiterOutcome> => {
+      console.log(`[Etymology API] Waiting for in-flight result for "${normalizedWord}" (stream)`)
+      const startedAt = Date.now()
+      const { waiterPollIntervalMs, streamWaiterMaxWaitMs } = CONFIG.singleflight
+
+      while (Date.now() - startedAt < streamWaiterMaxWaitMs) {
+        await sleep(waiterPollIntervalMs)
+
+        const result = await getCachedEtymology(normalizedWord)
+        if (result) {
+          return { kind: 'result', result }
+        }
+
+        if (await getNegativeCache(normalizedWord)) {
+          return { kind: 'negative_cached' }
+        }
+
+        if (!(await isLockHeld(lockKey))) {
+          const promotion = await tryAcquireLock(lockKey)
+          if (promotion.status === 'acquired') {
+            console.log(`[Etymology API] Promoted waiter to holder for "${normalizedWord}"`)
+            return runHolderPipeline(promotion.token, emit)
+          }
+          // Another waiter won the promotion race — keep polling.
+        }
+
+        emit({ type: 'singleflight_wait', waitedMs: Date.now() - startedAt })
       }
 
-      if (shouldStream) {
-        const stream = new ReadableStream({
-          async start(controller) {
-            const encoder = new TextEncoder()
-            const emit = (event: StreamEvent) => {
-              controller.enqueue(encoder.encode(`data: ${JSON.stringify(event)}\n\n`))
-            }
+      return { kind: 'timeout' }
+    }
 
-            try {
+    if (shouldStream) {
+      const stream = new ReadableStream({
+        async start(controller) {
+          const encoder = new TextEncoder()
+          const emit = (event: StreamEvent) => {
+            controller.enqueue(encoder.encode(`data: ${JSON.stringify(event)}\n\n`))
+          }
+
+          try {
+            let outcome: WaiterOutcome
+            if (acquisition.status === 'acquired') {
               console.log(
                 `[Etymology API] Starting agentic research (streaming) for "${normalizedWord}"`
               )
-              const research = await runResearch(emit)
-              if (research.kind === 'no_sources') {
-                if (research.typoSuggestions && research.typoSuggestions.length > 0) {
-                  emit({
-                    type: 'error',
-                    message: `Hmm, we couldn't find "${word}".`,
-                    errorType: 'typo',
-                    suggestions: research.typoSuggestions,
-                  })
-                } else {
-                  emit({
-                    type: 'error',
-                    message: getQuirkyMessage('nonsense'),
-                    errorType: 'nonsense',
-                  })
-                }
-                controller.close()
-                return
-              }
-              const researchContext = research.researchContext
+              outcome = await runHolderPipeline(acquisition.token, emit)
+            } else {
+              outcome = await waitAsStreamingWaiter(emit)
+            }
 
-              emit({ type: 'synthesis_started' })
-
-              const { result, usage } = await streamSynthesis(researchContext, (token) => {
-                emit({ type: 'synthesis_token', token })
-              })
-
-              recordUsage(usage)
-
+            if (outcome.kind === 'result') {
               emit({
                 type: 'enrichment_done',
-                highConfidence: countConfidence(result, 'high'),
-                mediumConfidence: countConfidence(result, 'medium'),
+                highConfidence: countConfidence(outcome.result, 'high'),
+                mediumConfidence: countConfidence(outcome.result, 'medium'),
               })
-
-              emit({ type: 'result', data: result })
-
-              cacheAndAudit(researchContext, result)
-
-              controller.close()
-            } catch (error) {
-              console.error('[Etymology API] Streaming error:', safeError(error))
-              const classified = classifyApiError(error)
+              emit({ type: 'result', data: outcome.result })
+            } else if (outcome.kind === 'no_sources') {
+              if (outcome.typoSuggestions && outcome.typoSuggestions.length > 0) {
+                emit({
+                  type: 'error',
+                  message: `Hmm, we couldn't find "${word}".`,
+                  errorType: 'typo',
+                  suggestions: outcome.typoSuggestions,
+                })
+              } else {
+                emit({
+                  type: 'error',
+                  message: getQuirkyMessage('nonsense'),
+                  errorType: 'nonsense',
+                })
+              }
+            } else if (outcome.kind === 'negative_cached') {
               emit({
                 type: 'error',
-                message: classified.message,
-                errorType: classified.streamErrorType,
+                message: getQuirkyMessage('nonsense'),
+                errorType: 'nonsense',
               })
-              controller.close()
-            } finally {
-              // Release lock after stream completes
-              releaseLock(lockKey).catch(() => {})
+            } else {
+              emit({
+                type: 'error',
+                message: IN_PROGRESS_MESSAGE,
+                errorType: 'rate_limit',
+              })
             }
-          },
-        })
-
-        return new Response(stream, {
-          headers: {
-            'Content-Type': 'text/event-stream',
-            'Cache-Control': 'no-cache',
-            Connection: 'keep-alive',
-            'X-Protection-Mode': costMode,
-          },
-        })
-      } else {
-        console.log(`[Etymology API] Starting agentic research for "${normalizedWord}"`)
-        const research = await runResearch()
-        if (research.kind === 'no_sources') {
-          if (research.typoSuggestions && research.typoSuggestions.length > 0) {
-            return NextResponse.json<ApiResponse<{ suggestions: string[] }>>(
-              {
-                success: false,
-                error: `Hmm, we couldn't find "${word}". Did you mean:`,
-                data: { suggestions: research.typoSuggestions },
-              },
-              { status: 404 }
-            )
+          } catch (error) {
+            console.error('[Etymology API] Streaming error:', safeError(error))
+            void incrCounter('error')
+            const classified = classifyApiError(error)
+            emit({
+              type: 'error',
+              message: classified.message,
+              errorType: classified.streamErrorType,
+            })
           }
-          return NextResponse.json<ApiResponse<{ suggestion: string }>>(
-            {
-              success: false,
-              error: getQuirkyMessage('nonsense'),
-              data: { suggestion: research.fallbackSuggestion ?? getRandomWord() },
-            },
-            { status: 404 }
-          )
-        }
-        const researchContext = research.researchContext
+          controller.close()
+        },
+      })
 
-        const { result, usage } = await synthesizeFromResearch(researchContext)
-        recordUsage(usage)
-        cacheAndAudit(researchContext, result)
+      return new Response(stream, {
+        headers: {
+          'Content-Type': 'text/event-stream',
+          'Cache-Control': 'no-cache',
+          Connection: 'keep-alive',
+          'X-Protection-Mode': costMode,
+        },
+      })
+    }
 
+    // Non-streaming waiter: short poll, then ask the client to retry.
+    if (acquisition.status === 'busy') {
+      console.log(`[Etymology API] Waiting for in-flight result for "${normalizedWord}"`)
+      const result = await pollForResult(() => getCachedEtymology(normalizedWord))
+      if (result) {
         return NextResponse.json<ApiResponse<EtymologyResult> & { cached: boolean }>(
-          { success: true, data: result, cached: false },
-          {
-            headers: {
-              'Cache-Control': 'public, s-maxage=86400, stale-while-revalidate=604800',
-              'X-Protection-Mode': costMode,
-            },
-          }
+          { success: true, data: result, cached: true },
+          { headers: CACHED_RESPONSE_HEADERS }
         )
       }
-    } finally {
-      // Always release the lock for non-streaming path (streaming path releases in ReadableStream)
-      if (!shouldStream) {
-        releaseLock(lockKey).catch(() => {})
-      }
+      return NextResponse.json<ApiResponse<null>>(
+        { success: false, error: IN_PROGRESS_MESSAGE },
+        { status: 429, headers: { 'Retry-After': '15' } }
+      )
     }
+
+    console.log(`[Etymology API] Starting agentic research for "${normalizedWord}"`)
+    const outcome = await runHolderPipeline(acquisition.token)
+
+    if (outcome.kind === 'no_sources') {
+      if (outcome.typoSuggestions && outcome.typoSuggestions.length > 0) {
+        return NextResponse.json<ApiResponse<{ suggestions: string[] }>>(
+          {
+            success: false,
+            error: `Hmm, we couldn't find "${word}". Did you mean:`,
+            data: { suggestions: outcome.typoSuggestions },
+          },
+          { status: 404 }
+        )
+      }
+      return NextResponse.json<ApiResponse<{ suggestion: string }>>(
+        {
+          success: false,
+          error: getQuirkyMessage('nonsense'),
+          data: { suggestion: outcome.fallbackSuggestion ?? getRandomWord() },
+        },
+        { status: 404 }
+      )
+    }
+
+    return NextResponse.json<ApiResponse<EtymologyResult> & { cached: boolean }>(
+      { success: true, data: outcome.result, cached: false },
+      {
+        headers: {
+          ...CACHED_RESPONSE_HEADERS,
+          'X-Protection-Mode': costMode,
+        },
+      }
+    )
   } catch (error) {
     console.error('Etymology API error:', safeError(error))
+    void incrCounter('error')
     const classified = classifyApiError(error)
 
     return shouldStream

--- a/app/api/ngram/route.test.ts
+++ b/app/api/ngram/route.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, test } from 'bun:test'
+import { NextRequest } from 'next/server'
+import { GET } from '@/app/api/ngram/route'
+
+function ngramRequest(word?: string): NextRequest {
+  const url = new URL('http://localhost:3000/api/ngram')
+  if (word !== undefined) {
+    url.searchParams.set('word', word)
+  }
+  return new NextRequest(url)
+}
+
+describe('/api/ngram input validation', () => {
+  test('rejects a missing word parameter', async () => {
+    const response = await GET(ngramRequest())
+
+    expect(response.status).toBe(400)
+  })
+
+  test('rejects whitespace-only input', async () => {
+    const response = await GET(ngramRequest('   '))
+
+    expect(response.status).toBe(400)
+  })
+
+  test('rejects words with digits', async () => {
+    const response = await GET(ngramRequest('abc123'))
+
+    expect(response.status).toBe(400)
+  })
+
+  test('rejects words with shell/URL metacharacters', async () => {
+    for (const word of ['tele;phone', 'word?', 'a&b', 'hello!']) {
+      const response = await GET(ngramRequest(word))
+      expect(response.status).toBe(400)
+    }
+  })
+
+  test('rejects words longer than the max length', async () => {
+    const response = await GET(ngramRequest('a'.repeat(36)))
+
+    expect(response.status).toBe(400)
+  })
+})

--- a/app/api/ngram/route.ts
+++ b/app/api/ngram/route.ts
@@ -1,5 +1,6 @@
 import { NextRequest, NextResponse } from 'next/server'
 import { fetchNgram } from '@/lib/ngrams'
+import { isValidWord, canonicalizeWord } from '@/lib/validation'
 import { ApiResponse } from '@/lib/types'
 
 export async function GET(request: NextRequest) {
@@ -12,7 +13,16 @@ export async function GET(request: NextRequest) {
     )
   }
 
-  const result = await fetchNgram(word)
+  const normalized = canonicalizeWord(word)
+
+  if (!normalized || !isValidWord(normalized)) {
+    return NextResponse.json<ApiResponse<null>>(
+      { success: false, error: 'Invalid word' },
+      { status: 400 }
+    )
+  }
+
+  const result = await fetchNgram(normalized)
 
   if (!result || result.data.length === 0) {
     return NextResponse.json<ApiResponse<null>>(

--- a/app/api/pronunciation/route.ts
+++ b/app/api/pronunciation/route.ts
@@ -7,6 +7,9 @@ import { tryAcquireLock, releaseLock, pollForResult } from '@/lib/singleflight'
 import { safeError } from '@/lib/errorUtils'
 import { CONFIG } from '@/lib/config'
 
+// TTS generation has an 8s timeout, plus cache round-trips and waiter polling.
+export const maxDuration = 60
+
 /**
  * GET /api/pronunciation?word=example
  *
@@ -66,9 +69,9 @@ export async function GET(request: NextRequest) {
 
   // Singleflight: prevent duplicate TTS calls for the same word
   const lockKey = `lock:audio:${normalized}`
-  const acquiredLock = await tryAcquireLock(lockKey)
+  const acquisition = await tryAcquireLock(lockKey)
 
-  if (!acquiredLock) {
+  if (acquisition.status === 'busy') {
     // Another request is generating this audio — poll for it
     console.log(`[Pronunciation] Waiting for in-flight audio for "${normalized}"`)
     const result = await pollForResult(() => getCachedAudio(normalized))
@@ -84,9 +87,14 @@ export async function GET(request: NextRequest) {
     }
     return NextResponse.json(
       { success: false, error: 'Request in progress, please retry in a few seconds.' },
-      { status: 429, headers: { 'Retry-After': '2' } }
+      { status: 429, headers: { 'Retry-After': '5' } }
     )
   }
+
+  // 'unavailable' / 'error' fall through without a lock: pronunciation fails
+  // open because TTS cost is bounded (8s timeout, per-IP rate limits) and the
+  // endpoint must keep working when Redis is down.
+  const lockToken = acquisition.status === 'acquired' ? acquisition.token : null
 
   try {
     // Check cost mode — reject uncached expensive requests when budget is pressured
@@ -101,10 +109,9 @@ export async function GET(request: NextRequest) {
     const audioBuffer = await generatePronunciation(normalized)
     const base64 = Buffer.from(audioBuffer).toString('base64')
 
-    // Cache for future use (non-blocking)
-    cacheAudio(normalized, base64).catch((err) => {
-      console.error('[Pronunciation] Cache store failed:', safeError(err))
-    })
+    // Cache BEFORE the lock is released in `finally` so waiters polling
+    // the audio cache find the result instead of hitting 429.
+    await cacheAudio(normalized, base64)
 
     return new NextResponse(Buffer.from(audioBuffer), {
       headers: {
@@ -128,6 +135,8 @@ export async function GET(request: NextRequest) {
       { status: 500 }
     )
   } finally {
-    releaseLock(lockKey).catch(() => {})
+    if (lockToken) {
+      releaseLock(lockKey, lockToken).catch(() => {})
+    }
   }
 }

--- a/app/api/pronunciation/route.ts
+++ b/app/api/pronunciation/route.ts
@@ -136,7 +136,9 @@ export async function GET(request: NextRequest) {
     )
   } finally {
     if (lockToken) {
-      releaseLock(lockKey, lockToken).catch(() => {})
+      // Awaited: on serverless the context can freeze once the response
+      // returns, which would leave the lock held until its TTL expires.
+      await releaseLock(lockKey, lockToken)
     }
   }
 }

--- a/bun.lock
+++ b/bun.lock
@@ -11,7 +11,7 @@
         "@vercel/analytics": "^1.6.1",
         "@vercel/speed-insights": "^2.0.0",
         "lucide-react": "^0.563.0",
-        "next": "16.2.3",
+        "next": "16.2.6",
         "react": "19.2.3",
         "react-dom": "19.2.3",
         "zod": "^4.3.6",
@@ -163,25 +163,25 @@
 
     "@napi-rs/wasm-runtime": ["@napi-rs/wasm-runtime@0.2.12", "", { "dependencies": { "@emnapi/core": "^1.4.3", "@emnapi/runtime": "^1.4.3", "@tybys/wasm-util": "^0.10.0" } }, "sha512-ZVWUcfwY4E/yPitQJl481FjFo3K22D6qF0DuFH6Y/nbnE11GY5uguDxZMGXPQ8WQ0128MXQD7TnfHyK4oWoIJQ=="],
 
-    "@next/env": ["@next/env@16.2.3", "", {}, "sha512-ZWXyj4uNu4GCWQw9cjRxWlbD+33mcDszIo9iQxFnBX3Wmgq9ulaSJcl6VhuWx5pCWqqD+9W6Wfz7N0lM5lYPMA=="],
+    "@next/env": ["@next/env@16.2.6", "", {}, "sha512-gd8HoHN4ufj73WmR3JmVolrpJR47ILK6LouP5xElPglaVxir6e1a7VzvTvDWkOoPXT9rkkTzyCxBu4yeZfZwcw=="],
 
     "@next/eslint-plugin-next": ["@next/eslint-plugin-next@16.1.1", "", { "dependencies": { "fast-glob": "3.3.1" } }, "sha512-Ovb/6TuLKbE1UiPcg0p39Ke3puyTCIKN9hGbNItmpQsp+WX3qrjO3WaMVSi6JHr9X1NrmthqIguVHodMJbh/dw=="],
 
-    "@next/swc-darwin-arm64": ["@next/swc-darwin-arm64@16.2.3", "", { "os": "darwin", "cpu": "arm64" }, "sha512-u37KDKTKQ+OQLvY+z7SNXixwo4Q2/IAJFDzU1fYe66IbCE51aDSAzkNDkWmLN0yjTUh4BKBd+hb69jYn6qqqSg=="],
+    "@next/swc-darwin-arm64": ["@next/swc-darwin-arm64@16.2.6", "", { "os": "darwin", "cpu": "arm64" }, "sha512-ZJGkkcNfYgrrMkqOdZ7zoLa1TOy0qpcMfk/z4Mh/FKUz40gVO+HNQWqmLxf67Z5WB64DRp0dhEbyHfel+6sJUg=="],
 
-    "@next/swc-darwin-x64": ["@next/swc-darwin-x64@16.2.3", "", { "os": "darwin", "cpu": "x64" }, "sha512-gHjL/qy6Q6CG3176FWbAKyKh9IfntKZTB3RY/YOJdDFpHGsUDXVH38U4mMNpHVGXmeYW4wj22dMp1lTfmu/bTQ=="],
+    "@next/swc-darwin-x64": ["@next/swc-darwin-x64@16.2.6", "", { "os": "darwin", "cpu": "x64" }, "sha512-v/YLBHIY132Ced3puBJ7YJKw1lqsCrgcNo2aRJlCEyQrrCeRJlvGlnmxhPxNQI3KE3N1DN5r9TPNPvka3nq5RQ=="],
 
-    "@next/swc-linux-arm64-gnu": ["@next/swc-linux-arm64-gnu@16.2.3", "", { "os": "linux", "cpu": "arm64" }, "sha512-U6vtblPtU/P14Y/b/n9ZY0GOxbbIhTFuaFR7F4/uMBidCi2nSdaOFhA0Go81L61Zd6527+yvuX44T4ksnf8T+Q=="],
+    "@next/swc-linux-arm64-gnu": ["@next/swc-linux-arm64-gnu@16.2.6", "", { "os": "linux", "cpu": "arm64" }, "sha512-RPOvqlYBbcQjkz9VQQDZ2T2bARIjXZV1KFlt+V2Mr6SW/e4I9fcKsaA0hdyf2FHoTlsV2xnBd5Y912rP/1Ce6w=="],
 
-    "@next/swc-linux-arm64-musl": ["@next/swc-linux-arm64-musl@16.2.3", "", { "os": "linux", "cpu": "arm64" }, "sha512-/YV0LgjHUmfhQpn9bVoGc4x4nan64pkhWR5wyEV8yCOfwwrH630KpvRg86olQHTwHIn1z59uh6JwKvHq1h4QEw=="],
+    "@next/swc-linux-arm64-musl": ["@next/swc-linux-arm64-musl@16.2.6", "", { "os": "linux", "cpu": "arm64" }, "sha512-URUTu1+dMkxJsPFgm+OeEvq9wf5sujw0EvgYy80TDGHTSLTnIHeqb0Eu8A3sC95IRgjejQL+kC4mw+4yPxiAXA=="],
 
-    "@next/swc-linux-x64-gnu": ["@next/swc-linux-x64-gnu@16.2.3", "", { "os": "linux", "cpu": "x64" }, "sha512-/HiWEcp+WMZ7VajuiMEFGZ6cg0+aYZPqCJD3YJEfpVWQsKYSjXQG06vJP6F1rdA03COD9Fef4aODs3YxKx+RDQ=="],
+    "@next/swc-linux-x64-gnu": ["@next/swc-linux-x64-gnu@16.2.6", "", { "os": "linux", "cpu": "x64" }, "sha512-DOj182mPV8G3UkrayLoREM5YEYI+Dk5wv7Ox9xl1fFibAELEsFD0lDPfHIeILlutMMfdyhlzYPELG3peuKaurw=="],
 
-    "@next/swc-linux-x64-musl": ["@next/swc-linux-x64-musl@16.2.3", "", { "os": "linux", "cpu": "x64" }, "sha512-Kt44hGJfZSefebhk/7nIdivoDr3Ugp5+oNz9VvF3GUtfxutucUIHfIO0ZYO8QlOPDQloUVQn4NVC/9JvHRk9hw=="],
+    "@next/swc-linux-x64-musl": ["@next/swc-linux-x64-musl@16.2.6", "", { "os": "linux", "cpu": "x64" }, "sha512-HKQ5SP/V/ub73UvF7n/zeJlxk2kLmtL7Wzrg4WfmkjmNos5onJ2tKu7yZOPdL18A6Svfn3max29ym+ry7NkK4g=="],
 
-    "@next/swc-win32-arm64-msvc": ["@next/swc-win32-arm64-msvc@16.2.3", "", { "os": "win32", "cpu": "arm64" }, "sha512-O2NZ9ie3Tq6xj5Z5CSwBT3+aWAMW2PIZ4egUi9MaWLkwaehgtB7YZjPm+UpcNpKOme0IQuqDcor7BsW6QBiQBw=="],
+    "@next/swc-win32-arm64-msvc": ["@next/swc-win32-arm64-msvc@16.2.6", "", { "os": "win32", "cpu": "arm64" }, "sha512-LZXpTlPyS5v7HhSmnvsLGP3iIYgYOBnc8r8ArlT55sGHV89bR2HlDdBjWQ+PY6SJMmk8TuVGFuxalnP3k/0Dwg=="],
 
-    "@next/swc-win32-x64-msvc": ["@next/swc-win32-x64-msvc@16.2.3", "", { "os": "win32", "cpu": "x64" }, "sha512-Ibm29/GgB/ab5n7XKqlStkm54qqZE8v2FnijUPBgrd67FWrac45o/RsNlaOWjme/B5UqeWt/8KM4aWBwA1D2Kw=="],
+    "@next/swc-win32-x64-msvc": ["@next/swc-win32-x64-msvc@16.2.6", "", { "os": "win32", "cpu": "x64" }, "sha512-F0+4i0h9J6C4eE3EAPWsoCk7UW/dbzOjyzxY0qnDUOYFu6FFmdZ6l97/XdV3/Nz3VYyO7UWjyEJUXkGqcoXfMA=="],
 
     "@nodelib/fs.scandir": ["@nodelib/fs.scandir@2.1.5", "", { "dependencies": { "@nodelib/fs.stat": "2.0.5", "run-parallel": "^1.1.9" } }, "sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g=="],
 
@@ -709,7 +709,7 @@
 
     "natural-compare": ["natural-compare@1.4.0", "", {}, "sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw=="],
 
-    "next": ["next@16.2.3", "", { "dependencies": { "@next/env": "16.2.3", "@swc/helpers": "0.5.15", "baseline-browser-mapping": "^2.9.19", "caniuse-lite": "^1.0.30001579", "postcss": "8.4.31", "styled-jsx": "5.1.6" }, "optionalDependencies": { "@next/swc-darwin-arm64": "16.2.3", "@next/swc-darwin-x64": "16.2.3", "@next/swc-linux-arm64-gnu": "16.2.3", "@next/swc-linux-arm64-musl": "16.2.3", "@next/swc-linux-x64-gnu": "16.2.3", "@next/swc-linux-x64-musl": "16.2.3", "@next/swc-win32-arm64-msvc": "16.2.3", "@next/swc-win32-x64-msvc": "16.2.3", "sharp": "^0.34.5" }, "peerDependencies": { "@opentelemetry/api": "^1.1.0", "@playwright/test": "^1.51.1", "babel-plugin-react-compiler": "*", "react": "^18.2.0 || 19.0.0-rc-de68d2f4-20241204 || ^19.0.0", "react-dom": "^18.2.0 || 19.0.0-rc-de68d2f4-20241204 || ^19.0.0", "sass": "^1.3.0" }, "optionalPeers": ["@opentelemetry/api", "@playwright/test", "babel-plugin-react-compiler", "sass"], "bin": { "next": "dist/bin/next" } }, "sha512-9V3zV4oZFza3PVev5/poB9g0dEafVcgNyQ8eTRop8GvxZjV2G15FC5ARuG1eFD42QgeYkzJBJzHghNP8Ad9xtA=="],
+    "next": ["next@16.2.6", "", { "dependencies": { "@next/env": "16.2.6", "@swc/helpers": "0.5.15", "baseline-browser-mapping": "^2.9.19", "caniuse-lite": "^1.0.30001579", "postcss": "8.4.31", "styled-jsx": "5.1.6" }, "optionalDependencies": { "@next/swc-darwin-arm64": "16.2.6", "@next/swc-darwin-x64": "16.2.6", "@next/swc-linux-arm64-gnu": "16.2.6", "@next/swc-linux-arm64-musl": "16.2.6", "@next/swc-linux-x64-gnu": "16.2.6", "@next/swc-linux-x64-musl": "16.2.6", "@next/swc-win32-arm64-msvc": "16.2.6", "@next/swc-win32-x64-msvc": "16.2.6", "sharp": "^0.34.5" }, "peerDependencies": { "@opentelemetry/api": "^1.1.0", "@playwright/test": "^1.51.1", "babel-plugin-react-compiler": "*", "react": "^18.2.0 || 19.0.0-rc-de68d2f4-20241204 || ^19.0.0", "react-dom": "^18.2.0 || 19.0.0-rc-de68d2f4-20241204 || ^19.0.0", "sass": "^1.3.0" }, "optionalPeers": ["@opentelemetry/api", "@playwright/test", "babel-plugin-react-compiler", "sass"], "bin": { "next": "dist/bin/next" } }, "sha512-qOVgKJg1+At15NpeUP+eJgCHvTCgXsogweq87Ri/Ix7PkqQHg4sdaXmSFqKlgaIXE4kW0g25LE68W87UANlHtw=="],
 
     "node-releases": ["node-releases@2.0.27", "", {}, "sha512-nmh3lCkYZ3grZvqcCH+fjmQ7X+H0OeZgP40OierEaAptX4XofMh5kwNbWh7lBduUzCcV/8kZ+NDLCwm2iorIlA=="],
 

--- a/lib/cache.ts
+++ b/lib/cache.ts
@@ -3,17 +3,12 @@
  * Reduces API costs by caching LLM synthesis results.
  */
 
-import { Redis } from '@upstash/redis'
 import { EtymologyResult } from './types'
 import { EtymologyResultSchema } from './schemas/etymology'
 import { CONFIG } from './config'
+import { getRedis } from './redis'
 import { safeError } from './errorUtils'
 import { emitSecurityEvent } from './telemetry'
-
-const redis = new Redis({
-  url: process.env.ETYMOLOGY_KV_REST_API_URL || '',
-  token: process.env.ETYMOLOGY_KV_REST_API_TOKEN || '',
-})
 
 /** Apply ±jitter to a TTL to prevent synchronized cache stampedes */
 function jitterTTL(ttl: number): number {
@@ -34,7 +29,7 @@ const AUDIO_TTL = CONFIG.audioCacheTTL
  * Check if Redis caching is configured
  */
 export function isCacheConfigured(): boolean {
-  return !!(process.env.ETYMOLOGY_KV_REST_API_URL && process.env.ETYMOLOGY_KV_REST_API_TOKEN)
+  return getRedis() !== null
 }
 
 /**
@@ -43,7 +38,8 @@ export function isCacheConfigured(): boolean {
  * Uses Zod validation to detect schema mismatches from old cache entries
  */
 export async function getCachedEtymology(word: string): Promise<EtymologyResult | null> {
-  if (!isCacheConfigured()) return null
+  const redis = getRedis()
+  if (!redis) return null
 
   const key = `${ETYMOLOGY_PREFIX}${word.toLowerCase().trim()}`
   try {
@@ -76,7 +72,8 @@ export async function getCachedEtymology(word: string): Promise<EtymologyResult 
  * Cache etymology result for future lookups
  */
 export async function cacheEtymology(word: string, result: EtymologyResult): Promise<void> {
-  if (!isCacheConfigured()) return
+  const redis = getRedis()
+  if (!redis) return
 
   // Validate before writing to prevent caching invalid data
   const validated = EtymologyResultSchema.safeParse(result)
@@ -108,7 +105,8 @@ export async function cacheEtymology(word: string, result: EtymologyResult): Pro
  * Get cached audio (as base64 string)
  */
 export async function getCachedAudio(word: string): Promise<string | null> {
-  if (!isCacheConfigured()) return null
+  const redis = getRedis()
+  if (!redis) return null
 
   const key = `${AUDIO_PREFIX}${word.toLowerCase().trim()}`
   try {
@@ -123,7 +121,8 @@ export async function getCachedAudio(word: string): Promise<string | null> {
  * Cache audio (as base64 string)
  */
 export async function cacheAudio(word: string, audioBase64: string): Promise<void> {
-  if (!isCacheConfigured()) return
+  const redis = getRedis()
+  if (!redis) return
 
   const key = `${AUDIO_PREFIX}${word.toLowerCase().trim()}`
   try {
@@ -139,7 +138,8 @@ export async function cacheAudio(word: string, audioBase64: string): Promise<voi
  * Returns false on error (fail open).
  */
 export async function getNegativeCache(word: string): Promise<boolean> {
-  if (!isCacheConfigured()) return false
+  const redis = getRedis()
+  if (!redis) return false
 
   const key = `neg:v1:${word.toLowerCase().trim()}`
   try {
@@ -157,7 +157,8 @@ export async function getNegativeCache(word: string): Promise<boolean> {
  * Fails silently.
  */
 export async function cacheNegative(word: string, errorType: string): Promise<void> {
-  if (!isCacheConfigured()) return
+  const redis = getRedis()
+  if (!redis) return
 
   if (!CONFIG.cache.negativeCacheAdmitOnly.includes(errorType)) {
     return

--- a/lib/config.ts
+++ b/lib/config.ts
@@ -16,7 +16,6 @@ export const CONFIG = {
   // Input validation
   maxWordLength: 35,
   wordPattern: /^[\p{L}][\p{L}'\-]*[\p{L}]$|^[\p{L}]$/u, // Unicode letters + internal '/-
-  maxRequestBodyBytes: 1024,
 
   // Rate limits (per IP)
   rateLimit: {

--- a/lib/config.ts
+++ b/lib/config.ts
@@ -45,11 +45,13 @@ export const CONFIG = {
     tts: 8_000, // ElevenLabs
   },
 
-  // Singleflight deduplication
+  // Singleflight deduplication (owner-token locks, see lib/singleflight.ts)
   singleflight: {
-    lockTTL: 30, // seconds — auto-expires if holder crashes
-    pollIntervalMs: 500,
-    maxPolls: 16, // 8s total wait
+    lockTTLSeconds: 90, // auto-expires if holder crashes; holder heartbeats to extend
+    heartbeatIntervalMs: 30_000, // holder re-EXPIREs the lock while the pipeline runs
+    waiterPollIntervalMs: 2_000, // waiters re-check the cache at this cadence
+    streamWaiterMaxWaitMs: 150_000, // streaming waiters keep the SSE open this long
+    unaryWaiterMaxWaitMs: 10_000, // non-streaming waiters give up (429) after this
   },
 
   // USD-based cost tracking

--- a/lib/config.ts
+++ b/lib/config.ts
@@ -52,6 +52,7 @@ export const CONFIG = {
     waiterPollIntervalMs: 2_000, // waiters re-check the cache at this cadence
     streamWaiterMaxWaitMs: 150_000, // streaming waiters keep the SSE open this long
     unaryWaiterMaxWaitMs: 10_000, // non-streaming waiters give up (429) after this
+    failureMarkerTTLSeconds: 60, // holder-failure marker; blocks waiter promotion, not retries
   },
 
   // USD-based cost tracking

--- a/lib/config.ts
+++ b/lib/config.ts
@@ -54,9 +54,9 @@ export const CONFIG = {
 
   // USD-based cost tracking
   costTracking: {
-    pricingPerMillionTokens: { input: 0.75, output: 4.5 },
+    pricingPerMillionTokens: { input: 0.75, output: 4.5 }, // fallback when OpenRouter omits cost
     monthlyLimitUSD: 10.0,
-    cacheOnlyAtPercent: 1.0, // serve only cached results at 100%
+    cacheOnlyAtPercent: 0.9, // serve only cached results at 90% of budget
   },
 
   // Feature flags

--- a/lib/costGuard.test.ts
+++ b/lib/costGuard.test.ts
@@ -1,0 +1,109 @@
+import { describe, expect, test } from 'bun:test'
+import { recordSpend, getCostMode, getSpendStats, usageToUSD } from '@/lib/costGuard'
+import { CONFIG } from '@/lib/config'
+import { createInMemoryRedis } from '@/lib/testSupport/inMemoryRedis'
+
+const COST_KEY = `cost:usd:${new Date().toISOString().slice(0, 7)}`
+const { monthlyLimitUSD, cacheOnlyAtPercent, pricingPerMillionTokens } = CONFIG.costTracking
+
+describe('usageToUSD', () => {
+  test('prefers the OpenRouter provider-reported cost when present', () => {
+    expect(usageToUSD({ inputTokens: 1_000_000, outputTokens: 1_000_000, costUSD: 0.42 })).toBe(
+      0.42
+    )
+  })
+
+  test('falls back to config pricing math when no provider cost', () => {
+    expect(usageToUSD({ inputTokens: 2_000_000, outputTokens: 1_000_000 })).toBeCloseTo(
+      2 * pricingPerMillionTokens.input + pricingPerMillionTokens.output,
+      10
+    )
+  })
+})
+
+describe('recordSpend', () => {
+  test('accumulates extraction and synthesis spend across calls', async () => {
+    const redis = createInMemoryRedis()
+
+    // Root-extraction usage (previously thrown away) + synthesis usage.
+    await recordSpend({ inputTokens: 0, outputTokens: 0, costUSD: 0.01 }, redis)
+    await recordSpend({ inputTokens: 0, outputTokens: 0, costUSD: 0.02 }, redis)
+
+    expect(Number(await redis.get(COST_KEY))).toBeCloseTo(0.03, 10)
+  })
+
+  test('sets a TTL on the first increment', async () => {
+    const redis = createInMemoryRedis()
+
+    await recordSpend({ inputTokens: 0, outputTokens: 0, costUSD: 0.01 }, redis)
+
+    const ttl = redis.ttlMs(COST_KEY)
+    expect(ttl).not.toBeNull()
+    expect(ttl!).toBeGreaterThan(0)
+  })
+
+  test('repairs a missing TTL on later increments (EXPIRE NX)', async () => {
+    const redis = createInMemoryRedis()
+
+    // Simulate the legacy brittle state: a spend key with no TTL.
+    await redis.set(COST_KEY, '1.5')
+    expect(redis.ttlMs(COST_KEY)).toBeNull()
+
+    await recordSpend({ inputTokens: 0, outputTokens: 0, costUSD: 0.01 }, redis)
+
+    expect(redis.ttlMs(COST_KEY)).not.toBeNull()
+  })
+
+  test('does not shorten an existing TTL (EXPIRE NX skips keys with a TTL)', async () => {
+    const redis = createInMemoryRedis()
+    await recordSpend({ inputTokens: 0, outputTokens: 0, costUSD: 0.01 }, redis)
+    const ttlBefore = redis.ttlMs(COST_KEY)
+
+    await recordSpend({ inputTokens: 0, outputTokens: 0, costUSD: 0.01 }, redis)
+
+    // Same TTL (no clock movement in the mock between calls beyond ms noise).
+    expect(Math.abs(redis.ttlMs(COST_KEY)! - ttlBefore!)).toBeLessThan(1000)
+  })
+
+  test('is a no-op without Redis', async () => {
+    await recordSpend({ inputTokens: 1000, outputTokens: 1000, costUSD: 1 }, null)
+  })
+})
+
+describe('getCostMode 90% threshold', () => {
+  test('stays normal below 90% of the monthly limit', async () => {
+    const redis = createInMemoryRedis()
+    await redis.set(COST_KEY, String(monthlyLimitUSD * cacheOnlyAtPercent - 0.01))
+
+    expect(await getCostMode(redis)).toBe('normal')
+  })
+
+  test('switches to cache_only at 90% of the monthly limit', async () => {
+    const redis = createInMemoryRedis()
+    await redis.set(COST_KEY, String(monthlyLimitUSD * cacheOnlyAtPercent))
+
+    expect(await getCostMode(redis)).toBe('cache_only')
+  })
+
+  test('threshold is 90%, not 100%', () => {
+    expect(cacheOnlyAtPercent).toBe(0.9)
+  })
+
+  test('fails open to normal without Redis', async () => {
+    expect(await getCostMode(null)).toBe('normal')
+  })
+})
+
+describe('getSpendStats', () => {
+  test('reports accumulated spend, limit, and mode', async () => {
+    const redis = createInMemoryRedis()
+    await recordSpend({ inputTokens: 0, outputTokens: 0, costUSD: 1.25 }, redis)
+
+    const stats = await getSpendStats(redis)
+
+    expect(stats).not.toBeNull()
+    expect(stats!.spentUSD).toBeCloseTo(1.25, 10)
+    expect(stats!.limitUSD).toBe(monthlyLimitUSD)
+    expect(stats!.mode).toBe('normal')
+  })
+})

--- a/lib/costGuard.ts
+++ b/lib/costGuard.ts
@@ -2,9 +2,21 @@ import { CONFIG } from './config'
 import { getRedis } from './redis'
 import { safeError } from './errorUtils'
 import { emitSecurityEvent } from './telemetry'
-import type { ProtectionMode } from './types'
+import type { LlmUsage, ProtectionMode } from './types'
 
 export type CostMode = ProtectionMode
+
+/** Minimal Redis surface used by this module (allows in-memory test doubles). */
+export interface CostGuardRedis {
+  get(key: string): Promise<unknown>
+  pipeline(): CostGuardPipeline
+}
+
+export interface CostGuardPipeline {
+  incrbyfloat(key: string, value: number): CostGuardPipeline
+  expire(key: string, seconds: number, option: 'nx'): CostGuardPipeline
+  exec(): Promise<unknown>
+}
 
 const {
   pricingPerMillionTokens: pricing,
@@ -27,34 +39,47 @@ function secondsUntilNextMonth(now = new Date()): number {
   return Math.max(60, windowSeconds + safetyBufferSeconds)
 }
 
-export async function recordSpend(usage: {
-  inputTokens: number
-  outputTokens: number
-}): Promise<void> {
-  const redis = getRedis()
-  if (!redis) return
+/** Prefer the OpenRouter-reported USD cost; fall back to config pricing math. */
+export function usageToUSD(usage: LlmUsage): number {
+  if (usage.costUSD !== undefined) return usage.costUSD
+  return (usage.inputTokens * pricing.input + usage.outputTokens * pricing.output) / 1_000_000
+}
 
-  const usd = (usage.inputTokens * pricing.input + usage.outputTokens * pricing.output) / 1_000_000
+function parseSpend(raw: unknown): number {
+  const spent = Number(raw ?? 0)
+  return Number.isFinite(spent) ? spent : 0
+}
+
+/**
+ * Record LLM spend against the monthly budget.
+ * INCRBYFLOAT and EXPIRE NX run in one pipeline: NX sets the TTL only when
+ * the key has none, so every increment repairs a missing TTL (no brittle
+ * first-increment detection) without ever extending an existing one.
+ */
+export async function recordSpend(
+  usage: LlmUsage,
+  client: CostGuardRedis | null = getRedis()
+): Promise<void> {
+  if (!client) return
+
+  const usd = usageToUSD(usage)
+  if (usd <= 0) return
 
   try {
-    const key = costKey()
-    const result = await redis.incrbyfloat(key, usd)
-    // First increment: result ≈ usd (within floating-point tolerance)
-    if (Math.abs(result - usd) < 0.0001) {
-      await redis.expire(key, secondsUntilNextMonth())
-    }
+    const pipeline = client.pipeline()
+    pipeline.incrbyfloat(costKey(), usd)
+    pipeline.expire(costKey(), secondsUntilNextMonth(), 'nx')
+    await pipeline.exec()
   } catch (error) {
     console.error('[CostGuard] recordSpend failed:', safeError(error))
   }
 }
 
-export async function getCostMode(): Promise<CostMode> {
-  const redis = getRedis()
-  if (!redis) return 'normal'
+export async function getCostMode(client: CostGuardRedis | null = getRedis()): Promise<CostMode> {
+  if (!client) return 'normal'
 
   try {
-    const raw = await redis.get<number>(costKey())
-    const spent = raw ?? 0
+    const spent = parseSpend(await client.get(costKey()))
 
     const mode: CostMode = spent >= monthlyLimitUSD * cacheOnlyAtPercent ? 'cache_only' : 'normal'
 
@@ -73,19 +98,17 @@ export async function getCostMode(): Promise<CostMode> {
   }
 }
 
-export async function getSpendStats(): Promise<{
+export async function getSpendStats(client: CostGuardRedis | null = getRedis()): Promise<{
   spentUSD: number
   limitUSD: number
   mode: CostMode
   period: string
 } | null> {
-  const redis = getRedis()
-  if (!redis) return null
+  if (!client) return null
 
   try {
-    const raw = await redis.get<number>(costKey())
-    const spentUSD = raw ?? 0
-    const mode = await getCostMode()
+    const spentUSD = parseSpend(await client.get(costKey()))
+    const mode = await getCostMode(client)
     return { spentUSD, limitUSD: monthlyLimitUSD, mode, period: currentMonth() }
   } catch (error) {
     console.error('[CostGuard] getSpendStats failed:', safeError(error))

--- a/lib/counters.ts
+++ b/lib/counters.ts
@@ -1,0 +1,58 @@
+/**
+ * Cheap monthly operational counters (cache hits/misses/errors) backed by
+ * Redis INCR. Exposed via /api/admin/stats. All operations fail silently —
+ * counters are best-effort observability, never a request dependency.
+ */
+
+import { getRedis } from './redis'
+import { safeError } from './errorUtils'
+
+const COUNTER_NAMES = ['cache_hit', 'cache_miss', 'error'] as const
+
+export type CounterName = (typeof COUNTER_NAMES)[number]
+
+// Keys are month-scoped; keep two full months so a report at month boundary
+// still sees the previous period before the key expires.
+const COUNTER_TTL_SECONDS = 62 * 24 * 60 * 60
+
+function currentMonth(): string {
+  return new Date().toISOString().slice(0, 7)
+}
+
+function counterKey(name: CounterName): string {
+  return `counters:v1:${currentMonth()}:${name}`
+}
+
+export async function incrCounter(name: CounterName): Promise<void> {
+  const redis = getRedis()
+  if (!redis) return
+
+  try {
+    const key = counterKey(name)
+    const pipeline = redis.pipeline()
+    pipeline.incr(key)
+    pipeline.expire(key, COUNTER_TTL_SECONDS, 'nx')
+    await pipeline.exec()
+  } catch (error) {
+    console.error('[Counters] incrCounter failed:', safeError(error))
+  }
+}
+
+export async function getCounters(): Promise<Record<CounterName, number> | null> {
+  const redis = getRedis()
+  if (!redis) return null
+
+  try {
+    const values = await redis.mget<(number | null)[]>(
+      ...COUNTER_NAMES.map((name) => counterKey(name))
+    )
+    const counters = {} as Record<CounterName, number>
+    COUNTER_NAMES.forEach((name, index) => {
+      counters[name] = Number(values[index] ?? 0)
+    })
+    return counters
+  } catch (error) {
+    console.error('[Counters] getCounters failed:', safeError(error))
+    return null
+  }
+}

--- a/lib/errorUtils.test.ts
+++ b/lib/errorUtils.test.ts
@@ -1,0 +1,57 @@
+import { describe, expect, test } from 'bun:test'
+import { safeError } from '@/lib/errorUtils'
+
+describe('safeError secret redaction', () => {
+  test('redacts bare OpenRouter keys (no Bearer prefix)', () => {
+    const message = `401 invalid key sk-or-v1-${'a1b2c3d4'.repeat(8)} rejected`
+
+    const safe = safeError(new Error(message))
+
+    expect(safe).not.toInclude('sk-or-v1-a1b2c3d4')
+    expect(safe).toInclude('[REDACTED]')
+  })
+
+  test('redacts Upstash-style REST tokens', () => {
+    const token = 'AX4gACQgOTk1MmYtNGE3Yi04ZDNjLTBiMWU2YzJhZjQ5ZQ=='
+    const safe = safeError(`fetch failed for https://usw1-example.upstash.io with ${token}`)
+
+    expect(safe).not.toInclude(token)
+    expect(safe).toInclude('[REDACTED]')
+  })
+
+  test('still redacts Anthropic keys and Bearer tokens', () => {
+    const safe = safeError(
+      `sk-ant-api03-${'x'.repeat(24)} and Authorization: Bearer ${'y'.repeat(32)}`
+    )
+
+    expect(safe).not.toInclude('sk-ant-api03')
+    expect(safe).not.toInclude('y'.repeat(32))
+  })
+
+  test('redacts exact configured secret values wherever they appear', () => {
+    const previous = process.env.ETYMOLOGY_KV_REST_API_TOKEN
+    process.env.ETYMOLOGY_KV_REST_API_TOKEN = 'plain-looking-token-value-123'
+    try {
+      const safe = safeError('POST failed: token=plain-looking-token-value-123 in body')
+      expect(safe).not.toInclude('plain-looking-token-value-123')
+      expect(safe).toInclude('[REDACTED]')
+    } finally {
+      if (previous === undefined) {
+        delete process.env.ETYMOLOGY_KV_REST_API_TOKEN
+      } else {
+        process.env.ETYMOLOGY_KV_REST_API_TOKEN = previous
+      }
+    }
+  })
+
+  test('leaves ordinary error messages untouched', () => {
+    const message = 'Antidisestablishmentarianism failed to parse after 5000ms'
+
+    expect(safeError(new Error(message))).toBe(message)
+  })
+
+  test('handles non-Error values', () => {
+    expect(safeError({ code: 'ECONNRESET' })).toBe('{"code":"ECONNRESET"}')
+    expect(safeError('plain string')).toBe('plain string')
+  })
+})

--- a/lib/errorUtils.ts
+++ b/lib/errorUtils.ts
@@ -5,10 +5,22 @@
 
 const SECRET_PATTERNS = [
   /sk-ant-[a-zA-Z0-9\-_]{20,}/g,
+  /sk-or-v1-[a-zA-Z0-9]{16,}/g, // Bare OpenRouter keys (no Bearer prefix)
   /AIza[0-9A-Za-z\-_]{35}/g,
   /Bearer\s+[a-zA-Z0-9._\-]{20,}/gi, // Bearer tokens
   /[a-zA-Z0-9_]*api[_-]?key[:\s="']+\S{20,}/gi, // Generic API key assignments
+  // Upstash REST tokens: long base64-ish strings starting with "A". The 36+
+  // length floor keeps ordinary words (max ~29 chars in English) untouched.
+  /\bA[A-Za-z0-9+/_-]{35,}={0,2}/g,
 ]
+
+/** Env vars whose exact values must never appear in error messages. */
+const SECRET_ENV_VARS = [
+  'OPENROUTER_API_KEY',
+  'ETYMOLOGY_KV_REST_API_TOKEN',
+  'ELEVENLABS_API_KEY',
+  'ADMIN_SECRET',
+] as const
 
 /**
  * Extract a safe error message from an unknown error value.
@@ -33,6 +45,15 @@ export function safeError(error: unknown): string {
     // Reset lastIndex for global regexps
     pattern.lastIndex = 0
     message = message.replace(pattern, '[REDACTED]')
+  }
+
+  // Exact-value redaction of configured secrets — catches shapes the
+  // patterns above miss (e.g. tokens embedded in URLs or JSON payloads).
+  for (const envVar of SECRET_ENV_VARS) {
+    const value = process.env[envVar]
+    if (value && value.length >= 8 && message.includes(value)) {
+      message = message.split(value).join('[REDACTED]')
+    }
   }
 
   return message

--- a/lib/freeDictionary.test.ts
+++ b/lib/freeDictionary.test.ts
@@ -1,0 +1,47 @@
+import { afterEach, describe, expect, test } from 'bun:test'
+import { fetchFreeDictionary } from '@/lib/freeDictionary'
+
+const originalFetch = globalThis.fetch
+
+afterEach(() => {
+  globalThis.fetch = originalFetch
+})
+
+describe('fetchFreeDictionary timeout', () => {
+  test('aborts a hanging upstream instead of blocking the research phase', async () => {
+    // A fetch that never resolves unless the abort signal fires.
+    globalThis.fetch = ((_url: unknown, options?: RequestInit) =>
+      new Promise((_resolve, reject) => {
+        options?.signal?.addEventListener('abort', () => {
+          reject(new DOMException('The operation was aborted', 'AbortError'))
+        })
+      })) as typeof fetch
+
+    const startedAt = Date.now()
+    const result = await fetchFreeDictionary('telephone', 50)
+    const elapsed = Date.now() - startedAt
+
+    expect(result).toBeNull() // fails soft
+    expect(elapsed).toBeLessThan(1000) // did not hang past the timeout
+  })
+
+  test('returns the first entry from a healthy response', async () => {
+    globalThis.fetch = (() =>
+      Promise.resolve(
+        new Response(JSON.stringify([{ word: 'telephone', phonetics: [], meanings: [] }]), {
+          status: 200,
+        })
+      )) as unknown as typeof fetch
+
+    const result = await fetchFreeDictionary('telephone', 1000)
+
+    expect(result?.word).toBe('telephone')
+  })
+
+  test('returns null on 404 without throwing', async () => {
+    globalThis.fetch = (() =>
+      Promise.resolve(new Response('not found', { status: 404 }))) as unknown as typeof fetch
+
+    expect(await fetchFreeDictionary('zzzzz', 1000)).toBeNull()
+  })
+})

--- a/lib/freeDictionary.ts
+++ b/lib/freeDictionary.ts
@@ -1,3 +1,7 @@
+import { CONFIG } from './config'
+import { fetchWithTimeout } from './fetchUtils'
+import { safeError } from './errorUtils'
+
 export interface FreeDictionaryEntry {
   word: string
   phonetic?: string
@@ -15,11 +19,15 @@ export interface FreeDictionaryEntry {
   origin?: string
 }
 
-export async function fetchFreeDictionary(word: string): Promise<FreeDictionaryEntry | null> {
+export async function fetchFreeDictionary(
+  word: string,
+  timeoutMs: number = CONFIG.timeouts.source
+): Promise<FreeDictionaryEntry | null> {
   try {
-    const response = await fetch(
+    const response = await fetchWithTimeout(
       `https://api.dictionaryapi.dev/api/v2/entries/en/${encodeURIComponent(word)}`,
-      { next: { revalidate: 86400 } }
+      { next: { revalidate: 86400 } },
+      timeoutMs
     )
 
     if (!response.ok) {
@@ -32,7 +40,7 @@ export async function fetchFreeDictionary(word: string): Promise<FreeDictionaryE
     if (!entry || typeof entry !== 'object') return null
     return entry
   } catch (error) {
-    console.error('Free Dictionary fetch failed:', error)
+    console.error('Free Dictionary fetch failed:', safeError(error))
     return null
   }
 }

--- a/lib/llm.ts
+++ b/lib/llm.ts
@@ -1,4 +1,4 @@
-import { EtymologyResult, SourceReference, ResearchContext } from './types'
+import { EtymologyResult, LlmUsage, SourceReference, ResearchContext } from './types'
 import { SYSTEM_PROMPT, buildRichUserPrompt } from './prompts'
 import { buildResearchPrompt } from './research'
 import { enrichAncestryGraph, pruneUngroundedStages } from './etymologyEnricher'
@@ -14,13 +14,13 @@ import {
 
 export interface SynthesisResult {
   result: EtymologyResult
-  usage: { inputTokens: number; outputTokens: number }
+  usage: LlmUsage
 }
 
 class MalformedModelOutputError extends Error {
-  readonly usage: { inputTokens: number; outputTokens: number }
+  readonly usage: LlmUsage
 
-  constructor(message: string, usage: { inputTokens: number; outputTokens: number }) {
+  constructor(message: string, usage: LlmUsage) {
     super(message)
     this.name = 'MalformedModelOutputError'
     this.usage = usage
@@ -31,12 +31,12 @@ function isMalformedModelOutputError(error: unknown): error is MalformedModelOut
   return error instanceof MalformedModelOutputError
 }
 
-function addUsage(
-  total: { inputTokens: number; outputTokens: number },
-  delta: { inputTokens: number; outputTokens: number }
-): void {
+function addUsage(total: LlmUsage, delta: LlmUsage): void {
   total.inputTokens += delta.inputTokens
   total.outputTokens += delta.outputTokens
+  if (delta.costUSD !== undefined) {
+    total.costUSD = (total.costUSD ?? 0) + delta.costUSD
+  }
 }
 
 function isAbortLikeError(error: unknown): boolean {
@@ -269,7 +269,7 @@ function sanitizeModernUsage(result: EtymologyResult, researchContext: ResearchC
 
 async function callLlm(userPrompt: string): Promise<{
   text: string
-  usage: { inputTokens: number; outputTokens: number }
+  usage: LlmUsage
 }> {
   const request = buildSynthesisRequest(userPrompt)
   request.instructions = SYSTEM_PROMPT
@@ -292,9 +292,9 @@ async function callLlm(userPrompt: string): Promise<{
 
 async function generateEtymologyResponse(userPrompt: string): Promise<{
   result: EtymologyResult
-  usage: { inputTokens: number; outputTokens: number }
+  usage: LlmUsage
 }> {
-  const totalUsage = { inputTokens: 0, outputTokens: 0 }
+  const totalUsage: LlmUsage = { inputTokens: 0, outputTokens: 0 }
   const maxAttempts = CONFIG.retries.malformedOutputRetries + 1
   let lastMalformedError: MalformedModelOutputError | null = null
 
@@ -474,7 +474,7 @@ export async function streamSynthesis(
   request.instructions = SYSTEM_PROMPT
 
   let fullText = ''
-  let usage = { inputTokens: 0, outputTokens: 0 }
+  let usage: LlmUsage = { inputTokens: 0, outputTokens: 0 }
 
   try {
     const response = await streamOpenRouterResponse(

--- a/lib/openrouterResponses.ts
+++ b/lib/openrouterResponses.ts
@@ -1,6 +1,7 @@
 import { CONFIG } from '@/lib/config'
 import { getEnv } from '@/lib/env'
 import { fetchWithTimeout } from '@/lib/fetchUtils'
+import type { LlmUsage } from '@/lib/types'
 
 const ROOTS_JSON_SCHEMA = {
   type: 'object',
@@ -49,6 +50,7 @@ type OpenRouterResponseOutputItem = {
 type OpenRouterUsage = {
   input_tokens?: number
   output_tokens?: number
+  cost?: number | null // OpenRouter-reported USD cost (present on unary + streaming)
   output_tokens_details?: {
     reasoning_tokens?: number
   } | null
@@ -253,13 +255,12 @@ export function extractOutputText(response: OpenRouterResponseLike): string {
   )
 }
 
-export function extractUsage(response: OpenRouterResponseLike): {
-  inputTokens: number
-  outputTokens: number
-} {
+export function extractUsage(response: OpenRouterResponseLike): LlmUsage {
+  const cost = response.usage?.cost
   return {
     inputTokens: response.usage?.input_tokens ?? 0,
     outputTokens: response.usage?.output_tokens ?? 0,
+    ...(typeof cost === 'number' && Number.isFinite(cost) && cost >= 0 ? { costUSD: cost } : {}),
   }
 }
 

--- a/lib/redis.ts
+++ b/lib/redis.ts
@@ -1,16 +1,26 @@
 /**
  * Shared Redis client factory.
- * Returns null if Redis is not configured (all callers fail open).
+ * Returns null if Redis is not configured. Callers decide their failure
+ * policy: most fail open, but uncached etymology synthesis fails closed
+ * (see app/api/etymology/route.ts) because running without Redis means
+ * no budget enforcement, no dedup, and no caching.
  */
 
 import { Redis } from '@upstash/redis'
 
+let client: Redis | null | undefined
+
 export function getRedis(): Redis | null {
+  if (client !== undefined) return client
+
   if (!process.env.ETYMOLOGY_KV_REST_API_URL || !process.env.ETYMOLOGY_KV_REST_API_TOKEN) {
-    return null
+    client = null
+    return client
   }
-  return new Redis({
+
+  client = new Redis({
     url: process.env.ETYMOLOGY_KV_REST_API_URL,
     token: process.env.ETYMOLOGY_KV_REST_API_TOKEN,
   })
+  return client
 }

--- a/lib/research.ts
+++ b/lib/research.ts
@@ -10,7 +10,13 @@ import { fetchWikipedia } from './wikipedia'
 import { fetchUrbanDictionary } from './urbanDictionary'
 import { fetchIncelsWiki } from './incelsWiki'
 import { fetchFreeDictionary } from './freeDictionary'
-import { RelatedTermResearchData, ResearchContext, RootResearchData, StreamEvent } from './types'
+import {
+  LlmUsage,
+  RelatedTermResearchData,
+  ResearchContext,
+  RootResearchData,
+  StreamEvent,
+} from './types'
 import { parseSourceTexts, formatParsedChainsForPrompt } from './etymologyParser'
 import { CONFIG } from './config'
 import { safeError } from './errorUtils'
@@ -18,17 +24,23 @@ import {
   buildRootExtractionRequest,
   createOpenRouterResponse,
   extractOutputText,
+  extractUsage,
 } from './openrouterResponses'
+
+export interface RootExtraction {
+  roots: string[]
+  usage: LlmUsage | null // null when no LLM call was made (or it failed before billing)
+}
 
 export async function extractRootsQuick(
   word: string,
   etymonlineText: string | null,
   wiktionaryText: string | null
-): Promise<string[]> {
+): Promise<RootExtraction> {
   const sourceText = [etymonlineText, wiktionaryText].filter(Boolean).join('\n\n')
 
   if (!sourceText) {
-    return []
+    return { roots: [], usage: null }
   }
 
   const prompt = `Analyze this etymology data and extract the ETYMOLOGICAL root morphemes of the word "${word}".
@@ -52,16 +64,25 @@ Examples:
 
 Return the JSON object only, no explanation:`
 
+  let response
   try {
     const request = buildRootExtractionRequest(prompt)
     request.instructions =
       'Extract root morphemes only. Return {"roots":["root"]} with lowercase strings and no commentary.'
 
-    const response = await createOpenRouterResponse(request)
-    return parseRootsArray(extractOutputText(response))
+    response = await createOpenRouterResponse(request)
   } catch (error) {
     console.error('Root extraction error:', safeError(error))
-    return []
+    return { roots: [], usage: null }
+  }
+
+  // The call was billed even if the output is unusable — always report usage.
+  const usage = extractUsage(response)
+  try {
+    return { roots: parseRootsArray(extractOutputText(response)), usage }
+  } catch (error) {
+    console.error('Root extraction error:', safeError(error))
+    return { roots: [], usage }
   }
 }
 
@@ -258,7 +279,10 @@ export async function conductAgenticResearch(
   const normalizedWord = word.toLowerCase().trim()
   const skipOptional = options?.skipOptionalSources ?? false
 
-  const runOptionalSource = <T>(
+  // Every source fails soft: a throwing client must not reject the whole
+  // Promise.all and lose the other five sources. The no-etymonline-AND-no-
+  // wiktionary check below already handles the nothing-found case.
+  const runSource = <T>(
     source: string,
     startTime: number,
     fetcher: () => Promise<T | null>,
@@ -281,41 +305,6 @@ export async function conductAgenticResearch(
           source,
           error: safeError(err),
         })
-        return null
-      })
-  }
-
-  const runRequiredSource = <T>(
-    source: string,
-    startTime: number,
-    fetcher: () => Promise<T | null>,
-    preview: (data: T | null) => string | undefined,
-    options?: { failHard?: boolean }
-  ): Promise<T | null> => {
-    const failHard = options?.failHard ?? true
-    return fetcher()
-      .then((data) => {
-        emitProgress(onProgress, {
-          type: 'source_complete',
-          source,
-          timing: Date.now() - startTime,
-          preview: preview(data),
-        })
-        return data
-      })
-      .catch((err) => {
-        if (!failHard) {
-          console.error(
-            `[Research] ${source} fetch failed for "${normalizedWord}":`,
-            safeError(err)
-          )
-        }
-        emitProgress(onProgress, {
-          type: 'source_failed',
-          source,
-          error: safeError(err),
-        })
-        if (failHard) throw err
         return null
       })
   }
@@ -344,28 +333,27 @@ export async function conductAgenticResearch(
     wikipediaData,
     incelsWikiData,
   ] = await Promise.all([
-    runRequiredSource(
+    runSource(
       'etymonline',
       startTime,
       () => fetchEtymonline(normalizedWord),
       (data) => data?.text.slice(0, 100)
     ),
-    runRequiredSource(
+    runSource(
       'wiktionary',
       startTime,
       () => fetchWiktionary(normalizedWord),
       (data) => data?.text.slice(0, 100)
     ),
-    runRequiredSource(
+    runSource(
       'freeDictionary',
       startTime,
       () => fetchFreeDictionary(normalizedWord),
-      (data) => data?.origin?.slice(0, 100),
-      { failHard: false }
+      (data) => data?.origin?.slice(0, 100)
     ),
     skipOptional
       ? Promise.resolve(null)
-      : runOptionalSource(
+      : runSource(
           'urbanDictionary',
           startTime,
           () => fetchUrbanDictionary(normalizedWord),
@@ -373,7 +361,7 @@ export async function conductAgenticResearch(
         ),
     skipOptional
       ? Promise.resolve(null)
-      : runOptionalSource(
+      : runSource(
           'wikipedia',
           startTime,
           () => fetchWikipedia(normalizedWord),
@@ -381,7 +369,7 @@ export async function conductAgenticResearch(
         ),
     skipOptional
       ? Promise.resolve(null)
-      : runOptionalSource(
+      : runSource(
           'incelsWiki',
           startTime,
           () => fetchIncelsWiki(normalizedWord),
@@ -437,11 +425,14 @@ export async function conductAgenticResearch(
 
   // Phase 2: Extract roots from initial data
   console.log('[Research] Phase 2: Extracting roots')
-  const identifiedRoots = await extractRootsQuick(
+  const { roots: identifiedRoots, usage: extractionUsage } = await extractRootsQuick(
     normalizedWord,
     etymonlineData?.text ?? null,
     wiktionaryData?.text ?? null
   )
+  if (extractionUsage) {
+    context.llmUsage = extractionUsage
+  }
   context.identifiedRoots = identifiedRoots
   console.log(`[Research] Identified roots: ${identifiedRoots.join(', ') || 'none'}`)
   emitProgress(onProgress, {

--- a/lib/singleflight.test.ts
+++ b/lib/singleflight.test.ts
@@ -1,0 +1,174 @@
+import { describe, expect, test } from 'bun:test'
+import {
+  tryAcquireLock,
+  releaseLock,
+  startLockHeartbeat,
+  isLockHeld,
+  pollForResult,
+} from '@/lib/singleflight'
+import { createInMemoryRedis, createFailingRedis } from '@/lib/testSupport/inMemoryRedis'
+
+const LOCK_KEY = 'lock:etymology:test-word'
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms))
+}
+
+describe('tryAcquireLock', () => {
+  test('acquires a free lock and returns an owner token', async () => {
+    const redis = createInMemoryRedis()
+
+    const acquisition = await tryAcquireLock(LOCK_KEY, redis)
+
+    expect(acquisition.status).toBe('acquired')
+    if (acquisition.status !== 'acquired') throw new Error('unreachable')
+    expect(acquisition.token.length).toBeGreaterThan(0)
+    expect(await isLockHeld(LOCK_KEY, redis)).toBe(true)
+  })
+
+  test('reports busy while another request holds the lock', async () => {
+    const redis = createInMemoryRedis()
+    await tryAcquireLock(LOCK_KEY, redis)
+
+    const second = await tryAcquireLock(LOCK_KEY, redis)
+
+    expect(second.status).toBe('busy')
+  })
+
+  test('sets a TTL so a crashed holder cannot deadlock the word', async () => {
+    const redis = createInMemoryRedis()
+    await tryAcquireLock(LOCK_KEY, redis)
+
+    const ttl = redis.ttlMs(LOCK_KEY)
+    expect(ttl).not.toBeNull()
+    expect(ttl!).toBeGreaterThan(0)
+  })
+
+  test('waiter can promote itself after the holder lock expires', async () => {
+    const redis = createInMemoryRedis()
+    await tryAcquireLock(LOCK_KEY, redis)
+
+    redis.advanceClock(91_000) // past the 90s TTL — holder crashed
+
+    expect(await isLockHeld(LOCK_KEY, redis)).toBe(false)
+    const promotion = await tryAcquireLock(LOCK_KEY, redis)
+    expect(promotion.status).toBe('acquired')
+  })
+
+  test('returns unavailable when Redis is not configured', async () => {
+    expect(await tryAcquireLock(LOCK_KEY, null)).toEqual({ status: 'unavailable' })
+  })
+
+  test('returns error when Redis rejects', async () => {
+    expect(await tryAcquireLock(LOCK_KEY, createFailingRedis())).toEqual({ status: 'error' })
+  })
+})
+
+describe('releaseLock owner-token safety', () => {
+  test('releases the lock when the token matches', async () => {
+    const redis = createInMemoryRedis()
+    const acquisition = await tryAcquireLock(LOCK_KEY, redis)
+    if (acquisition.status !== 'acquired') throw new Error('setup failed')
+
+    await releaseLock(LOCK_KEY, acquisition.token, redis)
+
+    expect(await isLockHeld(LOCK_KEY, redis)).toBe(false)
+  })
+
+  test('does NOT release a lock owned by someone else', async () => {
+    const redis = createInMemoryRedis()
+    const first = await tryAcquireLock(LOCK_KEY, redis)
+    if (first.status !== 'acquired') throw new Error('setup failed')
+
+    // First holder's lock expires; a second request acquires it.
+    redis.advanceClock(91_000)
+    const second = await tryAcquireLock(LOCK_KEY, redis)
+    if (second.status !== 'acquired') throw new Error('setup failed')
+
+    // Stale first holder tries to release with its old token — must be a no-op.
+    await releaseLock(LOCK_KEY, first.token, redis)
+
+    expect(await isLockHeld(LOCK_KEY, redis)).toBe(true)
+  })
+})
+
+describe('startLockHeartbeat', () => {
+  test('extends the lock TTL while running and stops when cleared', async () => {
+    const redis = createInMemoryRedis()
+    const acquisition = await tryAcquireLock(LOCK_KEY, redis)
+    if (acquisition.status !== 'acquired') throw new Error('setup failed')
+
+    // Move to 5s before expiry, then let the heartbeat refresh the TTL.
+    redis.advanceClock(85_000)
+    const stop = startLockHeartbeat(LOCK_KEY, acquisition.token, {
+      intervalMs: 10,
+      ttlSeconds: 90,
+      client: redis,
+    })
+    await sleep(40)
+    stop()
+
+    const ttl = redis.ttlMs(LOCK_KEY)
+    expect(ttl).not.toBeNull()
+    expect(ttl!).toBeGreaterThan(80_000) // refreshed back to ~90s
+
+    // After stop, the TTL keeps draining without refreshes.
+    redis.advanceClock(91_000)
+    expect(await isLockHeld(LOCK_KEY, redis)).toBe(false)
+  })
+
+  test('does not extend a lock that changed hands', async () => {
+    const redis = createInMemoryRedis()
+    const first = await tryAcquireLock(LOCK_KEY, redis)
+    if (first.status !== 'acquired') throw new Error('setup failed')
+
+    // First holder's lock expires and a new holder takes over.
+    redis.advanceClock(91_000)
+    const second = await tryAcquireLock(LOCK_KEY, redis)
+    if (second.status !== 'acquired') throw new Error('setup failed')
+    const ttlBefore = redis.ttlMs(LOCK_KEY)
+
+    // Stale heartbeat with the old token must not touch the new lock.
+    const stop = startLockHeartbeat(LOCK_KEY, first.token, {
+      intervalMs: 10,
+      ttlSeconds: 3600,
+      client: redis,
+    })
+    await sleep(40)
+    stop()
+
+    const ttlAfter = redis.ttlMs(LOCK_KEY)
+    expect(ttlAfter!).toBeLessThanOrEqual(ttlBefore!)
+  })
+})
+
+describe('pollForResult', () => {
+  test('returns the result once the holder caches it', async () => {
+    let cached: string | null = null
+    setTimeout(() => {
+      cached = 'the-result'
+    }, 25)
+
+    const result = await pollForResult(() => Promise.resolve(cached), {
+      intervalMs: 10,
+      maxWaitMs: 500,
+    })
+
+    expect(result).toBe('the-result')
+  })
+
+  test('returns null when nothing appears within the wait budget', async () => {
+    const result = await pollForResult(() => Promise.resolve(null), {
+      intervalMs: 10,
+      maxWaitMs: 50,
+    })
+
+    expect(result).toBeNull()
+  })
+})
+
+describe('isLockHeld', () => {
+  test('assumes held on Redis errors so waiters do not stampede', async () => {
+    expect(await isLockHeld(LOCK_KEY, createFailingRedis())).toBe(true)
+  })
+})

--- a/lib/singleflight.test.ts
+++ b/lib/singleflight.test.ts
@@ -4,6 +4,9 @@ import {
   releaseLock,
   startLockHeartbeat,
   isLockHeld,
+  markLockFailure,
+  getLockFailure,
+  attemptPromotion,
   pollForResult,
 } from '@/lib/singleflight'
 import { createInMemoryRedis, createFailingRedis } from '@/lib/testSupport/inMemoryRedis'
@@ -170,5 +173,95 @@ describe('pollForResult', () => {
 describe('isLockHeld', () => {
   test('assumes held on Redis errors so waiters do not stampede', async () => {
     expect(await isLockHeld(LOCK_KEY, createFailingRedis())).toBe(true)
+  })
+})
+
+describe('holder failure vs holder crash (promotion state machine)', () => {
+  test('holder failure: waiters get the error and never promote or re-run', async () => {
+    const redis = createInMemoryRedis()
+
+    // Holder acquires, fails, writes the marker, then releases (route order).
+    const holder = await tryAcquireLock(LOCK_KEY, redis)
+    if (holder.status !== 'acquired') throw new Error('setup failed')
+    await markLockFailure(LOCK_KEY, 'OpenRouter request timeout after 120000ms', redis)
+    await releaseLock(LOCK_KEY, holder.token, redis)
+
+    // Every waiter surfaces the failure; none acquires the lock.
+    for (let waiter = 0; waiter < 3; waiter++) {
+      const promotion = await attemptPromotion(LOCK_KEY, redis)
+      expect(promotion).toEqual({
+        status: 'holder_failed',
+        message: 'OpenRouter request timeout after 120000ms',
+      })
+    }
+    expect(await isLockHeld(LOCK_KEY, redis)).toBe(false) // no one re-ran the pipeline
+  })
+
+  test('true crash: lock expired with no marker — exactly one waiter promotes', async () => {
+    const redis = createInMemoryRedis()
+    await tryAcquireLock(LOCK_KEY, redis)
+    redis.advanceClock(91_000) // holder crashed; lock TTL expired, no marker
+
+    const first = await attemptPromotion(LOCK_KEY, redis)
+    const second = await attemptPromotion(LOCK_KEY, redis)
+
+    expect(first.status).toBe('promoted')
+    expect(second.status).toBe('held') // lost the race — keeps polling
+  })
+
+  test('holder still working: waiters keep polling', async () => {
+    const redis = createInMemoryRedis()
+    await tryAcquireLock(LOCK_KEY, redis)
+
+    expect(await attemptPromotion(LOCK_KEY, redis)).toEqual({ status: 'held' })
+  })
+
+  test('marker written between check and acquisition: lock is handed back', async () => {
+    const redis = createInMemoryRedis()
+
+    // Lock is free and unmarked at first check, but the failed holder's
+    // marker becomes visible by the post-acquisition re-check.
+    await markLockFailure(LOCK_KEY, 'synthesis failed', redis)
+
+    const promotion = await attemptPromotion(LOCK_KEY, redis)
+
+    expect(promotion).toEqual({ status: 'holder_failed', message: 'synthesis failed' })
+    expect(await isLockHeld(LOCK_KEY, redis)).toBe(false)
+  })
+
+  test('a failed promoted waiter cannot cascade into further promotions', async () => {
+    const redis = createInMemoryRedis()
+    await tryAcquireLock(LOCK_KEY, redis)
+    redis.advanceClock(91_000) // original holder truly crashed
+
+    const promoted = await attemptPromotion(LOCK_KEY, redis)
+    if (promoted.status !== 'promoted') throw new Error('setup failed')
+
+    // The promoted waiter's pipeline fails too: marker, then release.
+    await markLockFailure(LOCK_KEY, 'still failing', redis)
+    await releaseLock(LOCK_KEY, promoted.token, redis)
+
+    expect(await attemptPromotion(LOCK_KEY, redis)).toEqual({
+      status: 'holder_failed',
+      message: 'still failing',
+    })
+  })
+
+  test('marker expires so later fresh requests are not blocked forever', async () => {
+    const redis = createInMemoryRedis()
+    await markLockFailure(LOCK_KEY, 'transient provider error', redis)
+
+    redis.advanceClock(61_000) // past the 60s marker TTL
+
+    expect(await getLockFailure(LOCK_KEY, redis)).toBeNull()
+    expect((await attemptPromotion(LOCK_KEY, redis)).status).toBe('promoted')
+  })
+
+  test('first failure message wins (marker is SET NX)', async () => {
+    const redis = createInMemoryRedis()
+    await markLockFailure(LOCK_KEY, 'first error', redis)
+    await markLockFailure(LOCK_KEY, 'second error', redis)
+
+    expect(await getLockFailure(LOCK_KEY, redis)).toBe('first error')
   })
 })

--- a/lib/singleflight.ts
+++ b/lib/singleflight.ts
@@ -3,46 +3,132 @@
  * Prevents N concurrent requests for the same uncached word
  * from triggering N parallel LLM calls.
  *
- * Pattern: first request acquires lock and does the work,
- * subsequent requests poll for the cached result.
+ * Design: owner-token lock (SET NX with a random token as the value).
+ * The pipeline can run for minutes, so the holder heartbeats EXPIRE
+ * while working and releases the lock only if it still owns it. The
+ * result is written to cache BEFORE release so waiters always find it.
+ *
+ * Release and heartbeat use GET-then-DEL/EXPIRE rather than a Lua
+ * script. This leaves a small race: if the lock expired mid-operation
+ * and another request acquired it between our GET and DEL, we would
+ * delete the new holder's lock. The window is milliseconds and the
+ * worst case is one duplicate LLM call (~$0.02), which we accept in
+ * exchange for a simple, mockable implementation.
  */
 
+import { randomUUID } from 'crypto'
 import { getRedis } from './redis'
 import { CONFIG } from './config'
+import { safeError } from './errorUtils'
+
+/** Minimal Redis surface used by this module (allows in-memory test doubles). */
+export interface SingleflightRedis {
+  set(key: string, value: string, opts: { nx: true; ex: number }): Promise<unknown>
+  get(key: string): Promise<unknown>
+  del(key: string): Promise<unknown>
+  exists(key: string): Promise<number>
+  expire(key: string, seconds: number): Promise<unknown>
+}
+
+export type LockAcquisition =
+  | { status: 'acquired'; token: string }
+  | { status: 'busy' }
+  | { status: 'unavailable' } // Redis not configured
+  | { status: 'error' } // Redis errored
 
 /**
  * Try to acquire a distributed lock for a cache key.
- * Returns true if lock acquired (caller should do the work).
- * Returns false if another request holds the lock (caller should poll).
- * Fails open if Redis unavailable.
+ * The caller decides the failure policy for 'unavailable' and 'error':
+ * etymology fails closed (503), pronunciation proceeds without a lock.
  */
-export async function tryAcquireLock(lockKey: string): Promise<boolean> {
-  const redis = getRedis()
-  if (!redis) return true // No Redis = no coordination, do the work
+export async function tryAcquireLock(
+  lockKey: string,
+  client: SingleflightRedis | null = getRedis()
+): Promise<LockAcquisition> {
+  if (!client) return { status: 'unavailable' }
 
+  const token = randomUUID()
   try {
-    // SET NX with EX: only sets if key doesn't exist, auto-expires
-    const result = await redis.set(lockKey, '1', {
+    const result = await client.set(lockKey, token, {
       nx: true,
-      ex: CONFIG.singleflight.lockTTL,
+      ex: CONFIG.singleflight.lockTTLSeconds,
     })
-    return result === 'OK'
-  } catch {
-    return true // Fail open — do the work rather than deadlock
+    return result === 'OK' ? { status: 'acquired', token } : { status: 'busy' }
+  } catch (error) {
+    console.error('[Singleflight] Lock acquisition failed:', safeError(error))
+    return { status: 'error' }
   }
 }
 
 /**
- * Release a previously acquired lock.
+ * Release a previously acquired lock, but only if we still own it
+ * (prevents deleting a lock another request acquired after ours expired).
  */
-export async function releaseLock(lockKey: string): Promise<void> {
-  const redis = getRedis()
-  if (!redis) return
+export async function releaseLock(
+  lockKey: string,
+  token: string,
+  client: SingleflightRedis | null = getRedis()
+): Promise<void> {
+  if (!client) return
 
   try {
-    await redis.del(lockKey)
+    const current = await client.get(lockKey)
+    if (current === token) {
+      await client.del(lockKey)
+    }
   } catch {
     // Lock will auto-expire via TTL — safe to ignore
+  }
+}
+
+/**
+ * Keep a held lock alive while long pipeline work runs.
+ * Re-EXPIREs the lock every heartbeat interval as long as we still own it.
+ * Returns a stop function — call it in `finally` when the work ends.
+ */
+export function startLockHeartbeat(
+  lockKey: string,
+  token: string,
+  options?: { intervalMs?: number; ttlSeconds?: number; client?: SingleflightRedis | null }
+): () => void {
+  const client = options?.client !== undefined ? options.client : getRedis()
+  if (!client) return () => {}
+
+  const intervalMs = options?.intervalMs ?? CONFIG.singleflight.heartbeatIntervalMs
+  const ttlSeconds = options?.ttlSeconds ?? CONFIG.singleflight.lockTTLSeconds
+
+  const timer = setInterval(() => {
+    void (async () => {
+      try {
+        const current = await client.get(lockKey)
+        if (current === token) {
+          await client.expire(lockKey, ttlSeconds)
+        }
+      } catch (error) {
+        console.error('[Singleflight] Heartbeat failed:', safeError(error))
+      }
+    })()
+  }, intervalMs)
+
+  return () => clearInterval(timer)
+}
+
+/**
+ * Check whether the lock key still exists. Waiters use this to detect a
+ * crashed holder (lock gone, no cached result) and promote themselves.
+ * On Redis errors, reports the lock as held so waiters keep polling
+ * instead of stampeding into promotion.
+ */
+export async function isLockHeld(
+  lockKey: string,
+  client: SingleflightRedis | null = getRedis()
+): Promise<boolean> {
+  if (!client) return false
+
+  try {
+    return (await client.exists(lockKey)) === 1
+  } catch {
+    return true
   }
 }
 
@@ -50,11 +136,16 @@ export async function releaseLock(lockKey: string): Promise<void> {
  * Poll for a cached result to appear (set by the lock holder).
  * Returns the result if found within the poll window, or null on timeout.
  */
-export async function pollForResult<T>(getCached: () => Promise<T | null>): Promise<T | null> {
-  const { pollIntervalMs, maxPolls } = CONFIG.singleflight
+export async function pollForResult<T>(
+  getCached: () => Promise<T | null>,
+  options?: { intervalMs?: number; maxWaitMs?: number }
+): Promise<T | null> {
+  const intervalMs = options?.intervalMs ?? CONFIG.singleflight.waiterPollIntervalMs
+  const maxWaitMs = options?.maxWaitMs ?? CONFIG.singleflight.unaryWaiterMaxWaitMs
 
-  for (let i = 0; i < maxPolls; i++) {
-    await new Promise((resolve) => setTimeout(resolve, pollIntervalMs))
+  const startedAt = Date.now()
+  while (Date.now() - startedAt < maxWaitMs) {
+    await new Promise((resolve) => setTimeout(resolve, intervalMs))
     const result = await getCached()
     if (result !== null) return result
   }

--- a/lib/singleflight.ts
+++ b/lib/singleflight.ts
@@ -132,6 +132,82 @@ export async function isLockHeld(
   }
 }
 
+function failureKey(lockKey: string): string {
+  return `${lockKey}:failed`
+}
+
+/**
+ * Record that the holder exited with an error (as opposed to crashing).
+ * Written BEFORE the lock is released so waiters can distinguish
+ * "holder failed — surface the error" from "holder crashed — take over".
+ * Short TTL: after it expires, fresh requests retry normally.
+ */
+export async function markLockFailure(
+  lockKey: string,
+  message: string,
+  client: SingleflightRedis | null = getRedis()
+): Promise<void> {
+  if (!client) return
+
+  try {
+    await client.set(failureKey(lockKey), message, {
+      nx: true,
+      ex: CONFIG.singleflight.failureMarkerTTLSeconds,
+    })
+  } catch (error) {
+    console.error('[Singleflight] Failure marker write failed:', safeError(error))
+  }
+}
+
+/** Read the holder-failure message, or null if the holder didn't fail. */
+export async function getLockFailure(
+  lockKey: string,
+  client: SingleflightRedis | null = getRedis()
+): Promise<string | null> {
+  if (!client) return null
+
+  try {
+    const value = await client.get(failureKey(lockKey))
+    return typeof value === 'string' && value.length > 0 ? value : null
+  } catch {
+    return null
+  }
+}
+
+export type PromotionAttempt =
+  | { status: 'promoted'; token: string } // true crash — caller must run the pipeline
+  | { status: 'holder_failed'; message: string } // holder errored — surface, don't re-run
+  | { status: 'held' } // holder still working (or another waiter won the race)
+
+/**
+ * Waiter-side promotion decision. Promotes only on a true holder crash:
+ * the lock vanished with neither a cached result (caller checks that) nor
+ * a failure marker. The marker is re-checked AFTER acquiring the lock —
+ * holders write it before releasing, so a marker visible post-acquisition
+ * means the holder failed between our first check and the acquisition,
+ * and we must hand the lock back instead of duplicating the work.
+ */
+export async function attemptPromotion(
+  lockKey: string,
+  client: SingleflightRedis | null = getRedis()
+): Promise<PromotionAttempt> {
+  const failure = await getLockFailure(lockKey, client)
+  if (failure !== null) return { status: 'holder_failed', message: failure }
+
+  if (await isLockHeld(lockKey, client)) return { status: 'held' }
+
+  const acquisition = await tryAcquireLock(lockKey, client)
+  if (acquisition.status !== 'acquired') return { status: 'held' }
+
+  const lateFailure = await getLockFailure(lockKey, client)
+  if (lateFailure !== null) {
+    await releaseLock(lockKey, acquisition.token, client)
+    return { status: 'holder_failed', message: lateFailure }
+  }
+
+  return { status: 'promoted', token: acquisition.token }
+}
+
 /**
  * Poll for a cached result to appear (set by the lock holder).
  * Returns the result if found within the poll window, or null on timeout.

--- a/lib/testSupport/inMemoryRedis.ts
+++ b/lib/testSupport/inMemoryRedis.ts
@@ -1,0 +1,170 @@
+/**
+ * In-memory Redis test double with TTL support and an injectable clock.
+ * Implements the minimal surface used by lib/singleflight.ts and
+ * lib/costGuard.ts. Only imported from *.test.ts files.
+ */
+
+interface StoredEntry {
+  value: string
+  expiresAt: number | null // epoch ms, null = no TTL
+}
+
+export interface InMemoryRedis {
+  set(key: string, value: string, opts?: { nx?: true; ex?: number }): Promise<'OK' | null>
+  get(key: string): Promise<unknown>
+  del(key: string): Promise<number>
+  exists(key: string): Promise<number>
+  expire(key: string, seconds: number, option?: 'nx'): Promise<0 | 1>
+  incrbyfloat(key: string, value: number): Promise<number>
+  incr(key: string): Promise<number>
+  mget(...keys: string[]): Promise<(unknown | null)[]>
+  pipeline(): InMemoryPipeline
+  /** Test helpers */
+  ttlMs(key: string): number | null
+  advanceClock(ms: number): void
+  now(): number
+}
+
+export interface InMemoryPipeline {
+  incrbyfloat(key: string, value: number): InMemoryPipeline
+  incr(key: string): InMemoryPipeline
+  expire(key: string, seconds: number, option?: 'nx'): InMemoryPipeline
+  exec(): Promise<unknown[]>
+}
+
+export function createInMemoryRedis(): InMemoryRedis {
+  const store = new Map<string, StoredEntry>()
+  let clockOffset = 0
+
+  const now = () => Date.now() + clockOffset
+
+  const liveEntry = (key: string): StoredEntry | null => {
+    const entry = store.get(key)
+    if (!entry) return null
+    if (entry.expiresAt !== null && entry.expiresAt <= now()) {
+      store.delete(key)
+      return null
+    }
+    return entry
+  }
+
+  const redis: InMemoryRedis = {
+    async set(key, value, opts) {
+      if (opts?.nx && liveEntry(key)) return null
+      store.set(key, {
+        value,
+        expiresAt: opts?.ex !== undefined ? now() + opts.ex * 1000 : null,
+      })
+      return 'OK'
+    },
+
+    async get(key) {
+      const entry = liveEntry(key)
+      if (!entry) return null
+      // Mirror @upstash/redis behavior: numbers deserialize to numbers.
+      const numeric = Number(entry.value)
+      return entry.value !== '' && Number.isFinite(numeric) ? numeric : entry.value
+    },
+
+    async del(key) {
+      return liveEntry(key) && store.delete(key) ? 1 : 0
+    },
+
+    async exists(key) {
+      return liveEntry(key) ? 1 : 0
+    },
+
+    async expire(key, seconds, option) {
+      const entry = liveEntry(key)
+      if (!entry) return 0
+      if (option === 'nx' && entry.expiresAt !== null) return 0
+      entry.expiresAt = now() + seconds * 1000
+      return 1
+    },
+
+    async incrbyfloat(key, value) {
+      const entry = liveEntry(key)
+      const next = (entry ? Number(entry.value) : 0) + value
+      store.set(key, { value: String(next), expiresAt: entry?.expiresAt ?? null })
+      return next
+    },
+
+    async incr(key) {
+      const entry = liveEntry(key)
+      const next = (entry ? Number(entry.value) : 0) + 1
+      store.set(key, { value: String(next), expiresAt: entry?.expiresAt ?? null })
+      return next
+    },
+
+    async mget(...keys) {
+      return Promise.all(keys.map((key) => redis.get(key)))
+    },
+
+    pipeline() {
+      const operations: (() => Promise<unknown>)[] = []
+      const pipe: InMemoryPipeline = {
+        incrbyfloat(key, value) {
+          operations.push(() => redis.incrbyfloat(key, value))
+          return pipe
+        },
+        incr(key) {
+          operations.push(() => redis.incr(key))
+          return pipe
+        },
+        expire(key, seconds, option) {
+          operations.push(() => redis.expire(key, seconds, option))
+          return pipe
+        },
+        async exec() {
+          const results: unknown[] = []
+          for (const operation of operations) {
+            results.push(await operation())
+          }
+          return results
+        },
+      }
+      return pipe
+    },
+
+    ttlMs(key) {
+      const entry = liveEntry(key)
+      if (!entry || entry.expiresAt === null) return null
+      return entry.expiresAt - now()
+    },
+
+    advanceClock(ms) {
+      clockOffset += ms
+    },
+
+    now,
+  }
+
+  return redis
+}
+
+/** A client whose every operation rejects — simulates Redis being down. */
+export function createFailingRedis(): InMemoryRedis {
+  const fail = () => Promise.reject(new Error('redis connection refused'))
+  return {
+    set: fail,
+    get: fail,
+    del: fail,
+    exists: fail,
+    expire: fail,
+    incrbyfloat: fail,
+    incr: fail,
+    mget: fail,
+    pipeline() {
+      const pipe: InMemoryPipeline = {
+        incrbyfloat: () => pipe,
+        incr: () => pipe,
+        expire: () => pipe,
+        exec: fail,
+      }
+      return pipe
+    },
+    ttlMs: () => null,
+    advanceClock: () => {},
+    now: () => Date.now(),
+  }
+}

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -294,6 +294,7 @@ export type StreamEvent =
   | { type: 'root_research'; root: string; source: string; status: string }
   | { type: 'synthesis_started' }
   | { type: 'synthesis_token'; token: string }
+  | { type: 'singleflight_wait'; waitedMs: number }
   | {
       type: 'enrichment_done'
       highConfidence: number

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -145,6 +145,17 @@ export interface NgramResult {
 }
 
 /**
+ * Token and cost usage from a single LLM call.
+ * costUSD is the OpenRouter provider-reported cost when available;
+ * cost accounting falls back to config pricing math when absent.
+ */
+export interface LlmUsage {
+  inputTokens: number
+  outputTokens: number
+  costUSD?: number
+}
+
+/**
  * Complete etymology result for a word
  */
 export interface EtymologyResult {
@@ -241,6 +252,7 @@ export interface ResearchContext {
   relatedResearch: RelatedTermResearchData[]
   totalSourcesFetched: number
   parsedChains?: ParsedEtymChain[] // pre-parsed etymology chains from source text
+  llmUsage?: LlmUsage // root-extraction LLM usage, counted toward the budget
   rawSources?: {
     wikipedia?: string
     dateAttested?: string

--- a/proxy.ts
+++ b/proxy.ts
@@ -166,15 +166,37 @@ export async function proxy(request: NextRequest) {
 
   const response = NextResponse.next()
 
-  // CSP enforced for API responses
-  if (pathname.startsWith('/api/')) {
-    response.headers.set(
-      'Content-Security-Policy',
-      "default-src 'self'; script-src 'self' 'unsafe-inline' https://va.vercel-scripts.com; " +
-        "style-src 'self' 'unsafe-inline'; font-src 'self'; img-src 'self' data: https:; " +
-        "connect-src 'self'; frame-ancestors 'none'; base-uri 'self'; form-action 'self'"
-    )
-  }
+  // CSP for every matched response (HTML pages and API alike).
+  //
+  // script-src uses 'unsafe-inline' rather than a hash or nonce because the
+  // HTML pages are statically prerendered: Next.js bakes per-build
+  // `self.__next_f.push(...)` inline flight scripts into the HTML, which
+  // can't be hashed ahead of time, and nonces require dynamic rendering.
+  // Adding a hash alongside 'unsafe-inline' would make CSP2+ browsers ignore
+  // 'unsafe-inline' and break hydration. The policy still blocks scripts,
+  // objects, and frames from external hosts.
+  //
+  // Vercel Analytics + Speed Insights load same-origin /_vercel/* scripts in
+  // production (covered by 'self'); in dev they load debug scripts from
+  // va.vercel-scripts.com, and the dev toolchain needs 'unsafe-eval' + ws:.
+  const isDev = process.env.NODE_ENV === 'development'
+  const scriptSrc = isDev
+    ? "script-src 'self' 'unsafe-inline' 'unsafe-eval' https://va.vercel-scripts.com"
+    : "script-src 'self' 'unsafe-inline'"
+  const connectSrc = isDev ? "connect-src 'self' ws: wss:" : "connect-src 'self'"
+  const cspDirectives = [
+    "default-src 'self'",
+    scriptSrc,
+    "style-src 'self' 'unsafe-inline'",
+    "font-src 'self'",
+    "img-src 'self' data: https:",
+    connectSrc,
+    "object-src 'none'",
+    "frame-ancestors 'none'",
+    "base-uri 'self'",
+    "form-action 'self'",
+  ]
+  response.headers.set('Content-Security-Policy', cspDirectives.join('; '))
 
   if (pathname === '/') {
     response.headers.set('Link', AGENT_DISCOVERY_LINKS)
@@ -185,5 +207,8 @@ export async function proxy(request: NextRequest) {
 }
 
 export const config = {
-  matcher: ['/', '/api/:path*'],
+  // All pages and API routes; skip Next internals and static assets.
+  matcher: [
+    '/((?!_next/static|_next/image|favicon\\.ico|favicon\\.svg|fonts/|.*\\.(?:png|jpg|jpeg|gif|webp|svg|ico|txt|xml|json|woff2?)$).*)',
+  ],
 }

--- a/proxy.ts
+++ b/proxy.ts
@@ -190,6 +190,8 @@ export async function proxy(request: NextRequest) {
     "style-src 'self' 'unsafe-inline'",
     "font-src 'self'",
     "img-src 'self' data: https:",
+    // PronunciationButton plays TTS audio via URL.createObjectURL → blob:
+    "media-src 'self' blob:",
     connectSrc,
     "object-src 'none'",
     "frame-ancestors 'none'",


### PR DESCRIPTION
Implements branch A of the improvement plan: fixes the broken cost-safety mechanisms and closes a set of hardening gaps.

## Singleflight (was defeated for slow words)
- Owner-token locks: `SET NX` with a random token, 90s TTL, `EXPIRE` heartbeat every 30s while the pipeline runs (old: 30s TTL vs 30–255s work → duplicate LLM calls)
- Result is written to cache **before** lock release, so waiters always find it
- Streaming waiters poll the cache every 2s ≤150s, emit `singleflight_wait` SSE keepalives, check the negative cache, and promote themselves to holder if the lock vanishes with no result (old: 8s poll → 429)
- Non-streaming waiters poll ~10s, then 429 + `Retry-After`
- Release/heartbeat are owner-checked via GET-then-DEL/EXPIRE; the small race is documented in `lib/singleflight.ts` (worst case: one duplicate LLM call)
- `maxDuration = 300` on `/api/etymology`, `60` on `/api/pronunciation`

## Cost guard (accounting was wrong)
- Root-extraction LLM usage is returned from `extractRootsQuick` through `conductAgenticResearch` and recorded — previously thrown away, so every uncached search undercounted the budget
- `recordSpend` is awaited on both streaming and non-streaming paths (was fire-and-forget)
- Prefers OpenRouter's provider-reported `usage.cost` (USD) with config-pricing math as fallback — verified live that the Responses API returns `usage.cost` on both unary and streaming calls
- TTL fix: pipelined `INCRBYFLOAT` + `EXPIRE <key> <ttl> NX` — every increment repairs a missing TTL instead of relying on brittle first-increment detection
- Threshold collapsed to the real 2 modes: normal → cache_only at **90%** of the $10/month budget

## Redis-down fail-closed
- Uncached `/api/etymology` returns 503 when Redis is unavailable or errors (no budget cap, no dedup, no caching without it). Suggestions, random-word, and pronunciation keep working. Verified end-to-end locally.

## Page CSP
- Proxy matcher extended beyond `/api/` — all pages now get a CSP with `object-src 'none'`, `frame-ancestors 'none'`, `base-uri 'self'`
- **Deviation from plan:** `script-src` keeps `'unsafe-inline'` instead of the theme-script sha256 hash. The HTML pages are statically prerendered and carry per-build `self.__next_f.push(...)` inline flight scripts that cannot be hashed ahead of time; nonces require dynamic rendering; and a hash next to `'unsafe-inline'` makes CSP2+ browsers ignore `'unsafe-inline'`, breaking hydration. Verified with Playwright on the built app: zero CSP console violations, zero page errors, hydration works
- Dev-only allowances: `va.vercel-scripts.com`, `'unsafe-eval'`, `ws:`; production analytics load same-origin `/_vercel/*`

## Misc hardening
- `freeDictionary` uses `fetchWithTimeout` (could previously hang phase 1 past 5s)
- All research sources fail soft (removed the latent `failHard` Promise.all hazard)
- `cache.ts` uses the shared `getRedis()` factory (key names unchanged); client memoized
- Secret redaction covers bare `sk-or-v1-…`, Upstash-shaped tokens, and exact configured secret values
- `/api/ngram` validates input via `canonicalizeWord` + `isValidWord`
- Admin stats reads `ADMIN_SECRET` via `getEnv()` and exposes new monthly `cache_hit`/`cache_miss`/`error` counters
- `.env.example` documents `RATE_LIMIT_ENABLED`; dead `maxRequestBodyBytes` removed
- CLAUDE.md/README updated: 2-mode cost guard at 90%, singleflight redesign, "Edge" → Node middleware, endpoint tables gain `/api/ngram` + `/api/health`, cache version v2.2

## Tests (bun:test, colocated)
Singleflight state machine (acquire/busy/owner-token safety/heartbeat/promotion) against an in-memory Redis double, cost guard (TTL repair, 90% math, provider-cost preference, spend accumulation), redaction patterns, ngram validation rejects, freeDictionary abort. 58 tests pass.

## Verification
`bun test` (58 pass), `bun run lint`, `tsc --noEmit`, `bun run build` all green. Manual: CSP headers + Playwright console check on `next start`; fail-closed 503 verified with Redis unconfigured.

Note: `tsc` was verified with `@types/bun` installed locally; the dependency itself lands in #64 (merge-order dependency, not a conflict).

Merge order: merge 2nd, after the chore/ci-tests-benchmark PR (#64). Expected conflicts: none with it; later perf/feat PRs stack on this branch.

https://claude.ai/code/session_012GTdDDmz56DHGedvS2suof