### PR TITLE
chore: hold eslint and typescript majors in dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -16,6 +16,13 @@ updates:
       dependencies:
         patterns:
           - '*'
+    ignore:
+      # Held back until the toolchain catches up (see PR #70): eslint-config-next
+      # lacks ESLint 10 support and @types/bun lacks TypeScript 6 support.
+      - dependency-name: 'eslint'
+        update-types: ['version-update:semver-major']
+      - dependency-name: 'typescript'
+        update-types: ['version-update:semver-major']
 
   - package-ecosystem: 'github-actions'
     directory: '/'


### PR DESCRIPTION
Follow-up to #70, which pinned `eslint` back to `^9` and `typescript` back to `^5.9` after the #69 group bump broke CI on main (`eslint-config-next` 16.2.9 is incompatible with ESLint 10's removed `context.getFilename`; `tsc` 6.0.3 no longer resolves `bun:test` types from `@types/bun`).

Without this, Dependabot re-proposes both majors on its next weekly cycle and the group PR reintroduces the breakage. Adds `ignore` rules for `version-update:semver-major` on those two dependencies in the bun ecosystem (syntax per the current Dependabot options reference), with a YAML comment noting when to remove them: once `eslint-config-next` supports ESLint 10 and `@types/bun` supports TypeScript 6.

Merge anytime — one-file change, independent of other open PRs.

https://claude.ai/code/session_012GTdDDmz56DHGedvS2suof