### PR TITLE
feat: seamless sources→synthesis loading hand-off (persistent header + carried source summary)

### DIFF
--- a/components/ResearchProgress.tsx
+++ b/components/ResearchProgress.tsx
@@ -6,68 +6,57 @@ interface ResearchProgressProps {
   sources: SourceProgress[]
   parsingComplete: boolean
   sharedWaitMs: number | null
-  query?: string
 }
 
 export default function ResearchProgress({
   sources,
   parsingComplete,
   sharedWaitMs,
-  query,
 }: ResearchProgressProps) {
   return (
-    <section className="editorial-shell animate-fadeIn p-6 sm:p-8 lg:p-10">
-      <div className="grid gap-10 lg:grid-cols-[1.05fr_0.95fr]">
-        <div>
-          <p className="text-[11px] uppercase tracking-[0.24em] text-charcoal-light/62">
-            researching
-          </p>
-          <h2 className="mt-3 font-serif text-4xl tracking-[-0.05em] text-charcoal sm:text-5xl lg:text-6xl">
-            {query || 'your word'}
-          </h2>
-          <p className="mt-4 max-w-xl font-serif text-lg italic leading-relaxed text-charcoal-light">
-            Consulting the archive, cross-checking the sources, and assembling the line of descent.
-          </p>
+    <div className="mt-10 grid animate-fadeIn gap-10 lg:grid-cols-[1.05fr_0.95fr]">
+      <div>
+        <p className="max-w-xl font-serif text-lg italic leading-relaxed text-charcoal-light">
+          Consulting the archive, cross-checking the sources, and assembling the line of descent.
+        </p>
 
-          <div className="mt-8 space-y-4">
-            {parsingComplete && (
+        <div className="mt-8 space-y-4">
+          {parsingComplete && (
+            <div className="inline-flex items-center gap-2 text-sm text-charcoal/60">
+              <StatusMark complete />
+              <span className="font-serif italic">Parsing etymology chains</span>
+            </div>
+          )}
+
+          {sharedWaitMs !== null && (
+            <div className="animate-fadeIn">
               <div className="inline-flex items-center gap-2 text-sm text-charcoal/60">
-                <StatusMark complete />
-                <span className="font-serif italic">Parsing etymology chains</span>
+                <StatusMark />
+                <span className="font-serif italic">
+                  Another lookup for this word is already running — sharing its result
+                </span>
               </div>
-            )}
+            </div>
+          )}
+        </div>
+      </div>
 
-            {sharedWaitMs !== null && (
-              <div className="animate-fadeIn">
-                <div className="inline-flex items-center gap-2 text-sm text-charcoal/60">
-                  <StatusMark />
-                  <span className="font-serif italic">
-                    Another lookup for this word is already running — sharing its result
-                  </span>
-                </div>
-              </div>
-            )}
-          </div>
+      <aside className="editorial-card p-5 sm:p-6">
+        <div className="border-b border-border-soft pb-4">
+          <p className="text-[11px] uppercase tracking-[0.24em] text-charcoal-light/62">sources</p>
         </div>
 
-        <aside className="editorial-card p-5 sm:p-6">
-          <div className="border-b border-border-soft pb-4">
-            <p className="text-[11px] uppercase tracking-[0.24em] text-charcoal-light/62">
-              sources
-            </p>
-          </div>
-
-          <div
-            className={`
+        <div
+          className={`
               mt-5 overflow-hidden transition-all duration-500 ease-out
               ${parsingComplete ? 'opacity-85' : 'opacity-100'}
             `}
-          >
-            <div className="space-y-3">
-              {sources.map((source, index) => (
-                <div
-                  key={source.key}
-                  className={`
+        >
+          <div className="space-y-3">
+            {sources.map((source, index) => (
+              <div
+                key={source.key}
+                className={`
                     animate-fadeIn rounded-[0.95rem] border px-4 py-3
                     ${
                       source.status === 'complete'
@@ -77,34 +66,33 @@ export default function ResearchProgress({
                           : 'border-border-soft bg-paper-deep/45'
                     }
                   `}
-                  style={{ animationDelay: `${index * 50}ms` }}
-                >
-                  <div className="flex items-center gap-3">
-                    <SourceIcon status={source.status} />
-                    <span
-                      className={
-                        source.status === 'failed'
-                          ? 'font-medium text-red-700/85 dark:text-red-300/85'
-                          : 'font-medium text-charcoal/82'
-                      }
-                    >
-                      {source.label}
-                    </span>
-                    <span className="ml-auto text-xs uppercase tracking-[0.16em] text-charcoal-light/56">
-                      {source.status === 'complete'
-                        ? source.timing
-                          ? `${(source.timing / 1000).toFixed(1)}s`
-                          : 'done'
-                        : source.status}
-                    </span>
-                  </div>
+                style={{ animationDelay: `${index * 50}ms` }}
+              >
+                <div className="flex items-center gap-3">
+                  <SourceIcon status={source.status} />
+                  <span
+                    className={
+                      source.status === 'failed'
+                        ? 'font-medium text-red-700/85 dark:text-red-300/85'
+                        : 'font-medium text-charcoal/82'
+                    }
+                  >
+                    {source.label}
+                  </span>
+                  <span className="ml-auto text-xs uppercase tracking-[0.16em] text-charcoal-light/56">
+                    {source.status === 'complete'
+                      ? source.timing
+                        ? `${(source.timing / 1000).toFixed(1)}s`
+                        : 'done'
+                      : source.status}
+                  </span>
                 </div>
-              ))}
-            </div>
+              </div>
+            ))}
           </div>
-        </aside>
-      </div>
-    </section>
+        </div>
+      </aside>
+    </div>
   )
 }
 

--- a/components/SourceSummaryLine.tsx
+++ b/components/SourceSummaryLine.tsx
@@ -1,0 +1,23 @@
+'use client'
+
+import { formatSourceSummary, summarizeSources } from '@/lib/sourceSummary'
+import type { SourceProgress } from '@/lib/streamReducer'
+
+interface SourceSummaryLineProps {
+  sources: SourceProgress[]
+}
+
+/**
+ * Compact residue of the source chips, carried into the synthesis view beneath
+ * the persistent header. Echoes the `sources` eyebrow style and visually rhymes
+ * with the final card's Sources section without duplicating it. Renders nothing
+ * until at least one source has settled.
+ */
+export function SourceSummaryLine({ sources }: SourceSummaryLineProps) {
+  const line = formatSourceSummary(summarizeSources(sources))
+  if (!line) return null
+
+  return (
+    <p className="mt-5 text-[11px] uppercase tracking-[0.24em] text-charcoal-light/62">{line}</p>
+  )
+}

--- a/components/StreamingEtymologyCard.tsx
+++ b/components/StreamingEtymologyCard.tsx
@@ -3,7 +3,6 @@
 import type { NgramResult } from '@/lib/types'
 import type { PartialEtymology } from '@/lib/streamReducer'
 import { AncestrySection } from './etymology-card/AncestrySection'
-import { EntryHeader } from './etymology-card/EntryHeader'
 import { KinSection } from './etymology-card/KinSection'
 import {
   FIRST_SECTION_CLASS,
@@ -26,11 +25,14 @@ interface StreamingEtymologyCardProps {
 }
 
 /**
- * Progressive shell of the EtymologyCard shown while synthesis streams.
- * Each section component hydrates as its `synthesis_section` event lands
- * (schema order: header fields → ancestry → story → related → sources);
- * until then the header, ancestry, and story show skeleton placeholders.
- * The terminal `result` event swaps this card for the enriched final one.
+ * Progressive body of the EtymologyCard shown while synthesis streams.
+ *
+ * The persistent header lives in `TraceHeader` (mounted by
+ * WordTraceExperience across both loading phases), so this component renders
+ * only the body sections. Each hydrates as its `synthesis_section` event lands
+ * (schema order: ancestry → story → related → sources); until then ancestry and
+ * story show skeleton placeholders. The terminal `result` event swaps this card
+ * for the enriched final one.
  */
 export function StreamingEtymologyCard({
   word,
@@ -38,85 +40,47 @@ export function StreamingEtymologyCard({
   ngram,
   onWordClick,
 }: StreamingEtymologyCardProps) {
-  // `definition` is the third schema key: once it closes, word and
-  // pronunciation have closed too and the real header can render.
-  const headerReady = sections.definition !== undefined
-
-  const partialResult = {
-    word: sections.word ?? word,
-    pronunciation: sections.pronunciation ?? '',
-    definition: sections.definition ?? '',
-    roots: sections.roots ?? [],
-    ancestryGraph: sections.ancestryGraph ?? { branches: [] },
-    lore: sections.lore ?? '',
-    sources: sections.sources ?? [],
-    partsOfSpeech: sections.partsOfSpeech,
-    suggestions: sections.suggestions,
-    modernUsage: sections.modernUsage,
-    ngram: ngram ?? undefined,
-  }
+  const resolvedWord = sections.word ?? word
 
   return (
-    <article aria-busy="true" className="editorial-shell animate-fadeIn p-6 sm:p-8 md:p-12">
-      <div className="relative">
-        {headerReady ? <EntryHeader result={partialResult} /> : <HeaderSkeleton word={word} />}
+    <div className="relative animate-fadeIn">
+      {sections.ancestryGraph && sections.ancestryGraph.branches?.length > 0 ? (
+        <AncestrySection graph={sections.ancestryGraph} word={resolvedWord} />
+      ) : (
+        <AncestrySkeleton />
+      )}
 
-        {sections.ancestryGraph && sections.ancestryGraph.branches?.length > 0 ? (
-          <AncestrySection graph={sections.ancestryGraph} word={partialResult.word} />
-        ) : (
-          <AncestrySkeleton />
-        )}
+      {sections.lore !== undefined ? <StorySection lore={sections.lore} /> : <StorySkeleton />}
 
-        {sections.lore !== undefined ? <StorySection lore={sections.lore} /> : <StorySkeleton />}
+      {ngram && ngram.data.length > 0 && <UsageSection ngram={ngram} />}
 
-        {ngram && ngram.data.length > 0 && <UsageSection ngram={ngram} />}
+      {sections.modernUsage?.hasSlangMeaning && (
+        <ModernUsageSection modernUsage={sections.modernUsage} />
+      )}
 
-        {sections.modernUsage?.hasSlangMeaning && (
-          <ModernUsageSection modernUsage={sections.modernUsage} />
-        )}
+      {sections.suggestions && (
+        <RelatedWordsSection suggestions={sections.suggestions} onWordClick={onWordClick} />
+      )}
 
-        {sections.suggestions && (
-          <RelatedWordsSection suggestions={sections.suggestions} onWordClick={onWordClick} />
-        )}
+      {sections.roots && sections.roots.length > 0 && (
+        <KinSection roots={sections.roots} onWordClick={onWordClick} />
+      )}
 
-        {sections.roots && sections.roots.length > 0 && (
-          <KinSection roots={sections.roots} onWordClick={onWordClick} />
-        )}
+      {sections.sources && sections.sources.length > 0 && (
+        <SourcesSection sources={sections.sources} />
+      )}
 
-        {sections.sources && sections.sources.length > 0 && (
-          <SourcesSection sources={sections.sources} />
-        )}
-
-        <div className="mt-6 flex items-center justify-center gap-2 pt-2 text-charcoal/25">
-          <span className="w-8 h-px bg-current" />
-          <span className="text-xs font-serif italic select-none">§</span>
-          <span className="w-8 h-px bg-current" />
-        </div>
+      <div className="mt-6 flex items-center justify-center gap-2 pt-2 text-charcoal/25">
+        <span className="w-8 h-px bg-current" />
+        <span className="text-xs font-serif italic select-none">§</span>
+        <span className="w-8 h-px bg-current" />
       </div>
-    </article>
+    </div>
   )
 }
 
 function ShimmerBar({ className }: { className: string }) {
   return <div aria-hidden="true" className={`animate-pulse bg-charcoal/8 ${className}`} />
-}
-
-function HeaderSkeleton({ word }: { word: string }) {
-  return (
-    <header className="border-b border-border-soft pb-10">
-      <p className="text-[11px] uppercase tracking-[0.24em] text-charcoal-light/62">entry</p>
-      <div className="flex flex-wrap items-baseline gap-3 sm:gap-4">
-        <h1 className="mt-3 font-serif text-5xl font-semibold tracking-[-0.06em] text-charcoal md:text-7xl">
-          {word}
-        </h1>
-        <ShimmerBar className="h-5 w-28 rounded-full" />
-      </div>
-      <div className="mt-7 space-y-3">
-        <ShimmerBar className="h-6 w-3/4 max-w-xl rounded-full" />
-        <ShimmerBar className="h-4 w-1/2 max-w-md rounded-full" />
-      </div>
-    </header>
-  )
 }
 
 function AncestrySkeleton() {

--- a/components/TraceHeader.test.tsx
+++ b/components/TraceHeader.test.tsx
@@ -1,0 +1,37 @@
+import { describe, expect, test } from 'bun:test'
+import { renderToStaticMarkup } from 'react-dom/server'
+import { TraceHeader } from './TraceHeader'
+import type { PartialEtymology } from '@/lib/streamReducer'
+
+describe('TraceHeader', () => {
+  test('renders a shimmer skeleton before the definition arrives', () => {
+    const markup = renderToStaticMarkup(<TraceHeader word="perfidious" sections={{}} />)
+
+    expect(markup).toContain('perfidious')
+    expect(markup).toContain('animate-pulse')
+    // The real header's definition-driven nav is absent while skeletal.
+    expect(markup).not.toContain('#entry-sources')
+  })
+
+  test('promotes to the real header once the definition is present', () => {
+    const sections: PartialEtymology = {
+      word: 'perfidious',
+      pronunciation: '/pərˈfɪdiəs/',
+      definition: 'Deceitful and untrustworthy.',
+    }
+    const markup = renderToStaticMarkup(<TraceHeader word="perfidious" sections={sections} />)
+
+    expect(markup).toContain('Deceitful and untrustworthy.')
+    expect(markup).toContain('/pərˈfɪdiəs/')
+    expect(markup).toContain('#entry-sources')
+    expect(markup).not.toContain('animate-pulse')
+  })
+
+  test('renders the summary slot beneath the header', () => {
+    const markup = renderToStaticMarkup(
+      <TraceHeader word="perfidious" sections={{}} summary={<p>6 sources · 2.3s</p>} />
+    )
+
+    expect(markup).toContain('6 sources · 2.3s')
+  })
+})

--- a/components/TraceHeader.tsx
+++ b/components/TraceHeader.tsx
@@ -1,0 +1,59 @@
+'use client'
+
+import type { ReactNode } from 'react'
+import { toPartialResult, type PartialEtymology } from '@/lib/streamReducer'
+import { EntryHeader } from './etymology-card/EntryHeader'
+
+interface TraceHeaderProps {
+  /** The searched word — known before any section arrives */
+  word: string
+  sections: PartialEtymology
+  /** Optional slot rendered beneath the header border (source summary) */
+  summary?: ReactNode
+}
+
+/**
+ * Persistent header spanning both loading phases of the /word live trace.
+ *
+ * It stays mounted while the body swaps sources → synthesis, so the word title
+ * never remounts and cannot jump between layouts. A `HeaderSkeleton` holds the
+ * space until `definition` arrives (the third schema key — by then word and
+ * pronunciation have closed too), then the real `EntryHeader` promotes in place
+ * using the exact same markup as the final card.
+ */
+export function TraceHeader({ word, sections, summary }: TraceHeaderProps) {
+  const headerReady = sections.definition !== undefined
+
+  return (
+    <div className="relative">
+      {headerReady ? (
+        <EntryHeader result={toPartialResult(word, sections)} />
+      ) : (
+        <HeaderSkeleton word={word} />
+      )}
+      {summary}
+    </div>
+  )
+}
+
+function ShimmerBar({ className }: { className: string }) {
+  return <div aria-hidden="true" className={`animate-pulse bg-charcoal/8 ${className}`} />
+}
+
+function HeaderSkeleton({ word }: { word: string }) {
+  return (
+    <header className="border-b border-border-soft pb-10">
+      <p className="text-[11px] uppercase tracking-[0.24em] text-charcoal-light/62">entry</p>
+      <div className="flex flex-wrap items-baseline gap-3 sm:gap-4">
+        <h1 className="mt-3 font-serif text-5xl font-semibold tracking-[-0.06em] text-charcoal md:text-7xl">
+          {word}
+        </h1>
+        <ShimmerBar className="h-5 w-28 rounded-full" />
+      </div>
+      <div className="mt-7 space-y-3">
+        <ShimmerBar className="h-6 w-3/4 max-w-xl rounded-full" />
+        <ShimmerBar className="h-4 w-1/2 max-w-md rounded-full" />
+      </div>
+    </header>
+  )
+}

--- a/components/WordTraceExperience.tsx
+++ b/components/WordTraceExperience.tsx
@@ -9,7 +9,9 @@ import ResearchProgress from '@/components/ResearchProgress'
 import { ShareMenu } from '@/components/ShareMenu'
 import { SiteFooter } from '@/components/SiteFooter'
 import { SiteHeader } from '@/components/SiteHeader'
+import { SourceSummaryLine } from '@/components/SourceSummaryLine'
 import { StreamingEtymologyCard } from '@/components/StreamingEtymologyCard'
+import { TraceHeader } from '@/components/TraceHeader'
 import { useNgram } from '@/lib/hooks/useNgram'
 import { usePronunciation } from '@/lib/hooks/usePronunciation'
 import { useStreamingEtymology } from '@/lib/hooks/useStreamingEtymology'
@@ -108,22 +110,33 @@ export function WordTraceExperience({ word }: WordTraceExperienceProps) {
         <div className="mt-8">
           {!hasStarted && <TraceGate word={word} onStart={startTrace} />}
 
-          {showResearchProgress && (
-            <ResearchProgress
-              sources={progress.sources}
-              parsingComplete={progress.parsingComplete}
-              sharedWaitMs={progress.sharedWaitMs}
-              query={word}
-            />
-          )}
+          {isLoading && (
+            <article aria-busy="true" className="editorial-shell animate-fadeIn p-6 sm:p-8 md:p-12">
+              <TraceHeader
+                word={word}
+                sections={progress.sections}
+                summary={
+                  showStreamingCard ? <SourceSummaryLine sources={progress.sources} /> : null
+                }
+              />
 
-          {showStreamingCard && (
-            <StreamingEtymologyCard
-              word={word}
-              sections={progress.sections}
-              ngram={ngram}
-              onWordClick={navigateToWord}
-            />
+              {showResearchProgress && (
+                <ResearchProgress
+                  sources={progress.sources}
+                  parsingComplete={progress.parsingComplete}
+                  sharedWaitMs={progress.sharedWaitMs}
+                />
+              )}
+
+              {showStreamingCard && (
+                <StreamingEtymologyCard
+                  word={word}
+                  sections={progress.sections}
+                  ngram={ngram}
+                  onWordClick={navigateToWord}
+                />
+              )}
+            </article>
           )}
 
           {progress.status === 'error' && progress.error && (

--- a/lib/sourceSummary.test.ts
+++ b/lib/sourceSummary.test.ts
@@ -1,0 +1,95 @@
+import { describe, expect, test } from 'bun:test'
+import { formatSourceSummary, summarizeSources } from './sourceSummary'
+import type { SourceProgress } from './streamReducer'
+
+function source(key: string, status: SourceProgress['status'], timing?: number): SourceProgress {
+  return { key, label: key, status, ...(timing !== undefined ? { timing } : {}) }
+}
+
+describe('summarizeSources', () => {
+  test('counts completed, failed, and settled', () => {
+    const summary = summarizeSources([
+      source('a', 'complete', 1000),
+      source('b', 'complete', 2000),
+      source('c', 'failed'),
+    ])
+
+    expect(summary.completed).toBe(2)
+    expect(summary.failed).toBe(1)
+    expect(summary.settled).toBe(3)
+    expect(summary.total).toBe(3)
+    expect(summary.allSucceeded).toBe(false)
+  })
+
+  test('excludes pending sources from the total', () => {
+    const summary = summarizeSources([
+      source('a', 'complete', 1000),
+      source('b', 'pending'),
+      source('c', 'pending'),
+    ])
+
+    expect(summary.settled).toBe(1)
+    expect(summary.total).toBe(1)
+    expect(summary.completed).toBe(1)
+  })
+
+  test('wall time is the max timing over completed sources', () => {
+    const summary = summarizeSources([
+      source('a', 'complete', 1000),
+      source('b', 'complete', 2300),
+      source('c', 'complete', 1500),
+    ])
+
+    expect(summary.wallMs).toBe(2300)
+    expect(summary.allSucceeded).toBe(true)
+  })
+
+  test('wall time is null when no completed source reported timing', () => {
+    const summary = summarizeSources([source('a', 'complete'), source('b', 'failed')])
+
+    expect(summary.wallMs).toBeNull()
+  })
+
+  test('nothing settled yields an empty summary', () => {
+    const summary = summarizeSources([source('a', 'pending'), source('b', 'pending')])
+
+    expect(summary.settled).toBe(0)
+    expect(summary.total).toBe(0)
+    expect(summary.allSucceeded).toBe(false)
+  })
+})
+
+describe('formatSourceSummary', () => {
+  test('all succeeded, plural', () => {
+    const sources = Array.from({ length: 6 }, (_, i) => source(`s${i}`, 'complete', 1000 + i * 200))
+    expect(formatSourceSummary(summarizeSources(sources))).toBe('6 sources · 2.0s')
+  })
+
+  test('all succeeded, singular', () => {
+    expect(formatSourceSummary(summarizeSources([source('a', 'complete', 800)]))).toBe(
+      '1 source · 0.8s'
+    )
+  })
+
+  test('one failed shows the completed-of-total form', () => {
+    const sources = [
+      ...Array.from({ length: 5 }, (_, i) => source(`s${i}`, 'complete', 2400 - i * 100)),
+      source('f', 'failed'),
+    ]
+    expect(formatSourceSummary(summarizeSources(sources))).toBe('5 of 6 sources · 2.4s')
+  })
+
+  test('all failed omits the wall time', () => {
+    const sources = Array.from({ length: 3 }, (_, i) => source(`f${i}`, 'failed'))
+    expect(formatSourceSummary(summarizeSources(sources))).toBe('0 of 3 sources')
+  })
+
+  test('nothing settled returns null', () => {
+    expect(formatSourceSummary(summarizeSources([source('a', 'pending')]))).toBeNull()
+  })
+
+  test('rounds wall time to one decimal', () => {
+    const summary = summarizeSources([source('a', 'complete', 2345)])
+    expect(formatSourceSummary(summary)).toBe('1 source · 2.3s')
+  })
+})

--- a/lib/sourceSummary.ts
+++ b/lib/sourceSummary.ts
@@ -1,0 +1,72 @@
+/**
+ * Compact summary of the source-fetch phase, carried into the synthesis view
+ * once the individual source chips are swapped out. Pure and presentational —
+ * the type-only `SourceProgress` import is erased, so nothing new enters the
+ * runtime module graph.
+ */
+
+import type { SourceProgress } from './streamReducer'
+
+export interface SourceSummary {
+  /** Sources that finished successfully */
+  completed: number
+  /** Sources that failed */
+  failed: number
+  /** Sources that settled either way (completed + failed) */
+  settled: number
+  /** Denominator for the summary line — never-emitting optimistic seeds are
+   * excluded, so this equals `settled` rather than the seeded source count */
+  total: number
+  /** Wall-clock time for the parallel fetch = max timing over completed
+   * sources (parallel ⇒ wall ≈ max, not sum); null when none reported timing */
+  wallMs: number | null
+  /** True when at least one source settled and none failed */
+  allSucceeded: boolean
+}
+
+export function summarizeSources(sources: SourceProgress[]): SourceSummary {
+  let completed = 0
+  let failed = 0
+  let wallMs: number | null = null
+
+  for (const source of sources) {
+    if (source.status === 'complete') {
+      completed += 1
+      if (typeof source.timing === 'number') {
+        wallMs = wallMs === null ? source.timing : Math.max(wallMs, source.timing)
+      }
+    } else if (source.status === 'failed') {
+      failed += 1
+    }
+  }
+
+  const settled = completed + failed
+
+  return {
+    completed,
+    failed,
+    settled,
+    total: settled,
+    wallMs,
+    allSucceeded: settled > 0 && failed === 0,
+  }
+}
+
+/**
+ * Render the summary as a single muted line, or null when nothing has settled.
+ *
+ * Examples: "6 sources · 2.3s", "1 source · 0.8s", "5 of 6 sources · 2.4s",
+ * "0 of 3 sources" (all failed ⇒ no wall time).
+ */
+export function formatSourceSummary(summary: SourceSummary): string | null {
+  if (summary.settled === 0) return null
+
+  const noun = summary.total === 1 ? 'source' : 'sources'
+  const count = summary.allSucceeded
+    ? `${summary.total} ${noun}`
+    : `${summary.completed} of ${summary.total} ${noun}`
+
+  if (summary.wallMs === null) return count
+
+  return `${count} · ${(summary.wallMs / 1000).toFixed(1)}s`
+}

--- a/lib/streamReducer.test.ts
+++ b/lib/streamReducer.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, test } from 'bun:test'
 import {
   initialStreamState,
   streamReducer,
+  toPartialResult,
   type StreamAction,
   type StreamState,
 } from './streamReducer'
@@ -302,5 +303,30 @@ describe('fallback and reset', () => {
     ])
 
     expect(state).toEqual(initialStreamState)
+  })
+})
+
+describe('toPartialResult', () => {
+  test('falls back to the searched word and empty defaults before sections arrive', () => {
+    const partial = toPartialResult('perfidious', {})
+
+    expect(partial.word).toBe('perfidious')
+    expect(partial.pronunciation).toBe('')
+    expect(partial.definition).toBe('')
+    expect(partial.roots).toEqual([])
+    expect(partial.ancestryGraph).toEqual({ branches: [] })
+    expect(partial.sources).toEqual([])
+  })
+
+  test('prefers streamed sections and attaches the ngram when supplied', () => {
+    const ngram = { word: 'perfidious', data: [{ year: 1900, count: 5 }], corpus: 'en' }
+    const partial = toPartialResult(
+      'perfidious',
+      { word: 'perfidious', definition: 'Deceitful.' },
+      ngram
+    )
+
+    expect(partial.definition).toBe('Deceitful.')
+    expect(partial.ngram).toBe(ngram)
   })
 })

--- a/lib/streamReducer.ts
+++ b/lib/streamReducer.ts
@@ -8,7 +8,7 @@
  * there is no growing event array to rebuild from on every render.
  */
 
-import type { EtymologyResult, StreamEvent } from './types'
+import type { EtymologyResult, NgramResult, StreamEvent } from './types'
 import { StreamingUiError, toStreamingUiError } from './streamingError'
 
 export type StreamStatus = 'idle' | 'loading' | 'success' | 'error'
@@ -43,6 +43,32 @@ export type SectionKey = (typeof SECTION_KEYS)[number]
 
 /** Progressive slice of the final result, hydrated one section at a time */
 export type PartialEtymology = Partial<Pick<EtymologyResult, SectionKey>>
+
+/**
+ * Fill the streamed sections into a full-shaped EtymologyResult, defaulting
+ * every not-yet-arrived field to an empty value. Shared by the persistent
+ * TraceHeader and the StreamingEtymologyCard body so their partial-render
+ * views never drift.
+ */
+export function toPartialResult(
+  word: string,
+  sections: PartialEtymology,
+  ngram?: NgramResult | null
+): EtymologyResult {
+  return {
+    word: sections.word ?? word,
+    pronunciation: sections.pronunciation ?? '',
+    definition: sections.definition ?? '',
+    roots: sections.roots ?? [],
+    ancestryGraph: sections.ancestryGraph ?? { branches: [] },
+    lore: sections.lore ?? '',
+    sources: sections.sources ?? [],
+    partsOfSpeech: sections.partsOfSpeech,
+    suggestions: sections.suggestions,
+    modernUsage: sections.modernUsage,
+    ngram: ngram ?? undefined,
+  }
+}
 
 export interface StreamState {
   status: StreamStatus


### PR DESCRIPTION
## What

Smooths the transition on the `/word/[word]` live-trace view between the research "sources" loading screen and the progressive etymology card. Follow-up polish to the progressive rendering shipped in #74.

Previously the pre-synthesis `ResearchProgress` screen was a separate full-width 2-column layout that hard-swapped out the instant `synthesis_started` fired: the word title (rendered in three different layouts) visibly **jumped**, and all the source-fetch chips/timings were **discarded** even though the reducer still held them.

## How

- **Persistent header** — a new `TraceHeader` is hoisted into a single `editorial-shell` in `WordTraceExperience` that spans both loading phases; only the body swaps beneath it. The `<article>` + header stay mounted across sources↔synthesis, so the title cannot jump and fires no fade. It reuses the card's existing `HeaderSkeleton` → `EntryHeader` (promotes in place once `definition` arrives), so the final card needs no changes and the last swap stays smooth via matched shell padding.
- **Carried source summary** — a pure `lib/sourceSummary.ts` (`summarizeSources` / `formatSourceSummary`) derives a compact line from `progress.sources` (`"6 sources · 2.3s"`, `"5 of 6 sources · 2.4s"`, `null` when nothing settled; `total` = settled sources so optimistic never-emitting seeds and single-source words read correctly; wall-clock = max timing over completed, since fetches are parallel). Rendered by `SourceSummaryLine` in the header's summary slot during synthesis — the compact residue of the source chips.
- `StreamingEtymologyCard` and `ResearchProgress` become **body-only** (lose their own shell + word header). Shared `toPartialResult` extracted into `streamReducer.ts` (no state-shape change).

## Scope

Client-only `/word` live-trace UI. **Untouched:** `EtymologyCard`, `WordPageEntry` (cached path), `EntryHeader`. No new SSE events (uses existing reducer state). aria-live announcements and the global `prefers-reduced-motion` rule preserved.

## Tests

- `lib/sourceSummary.test.ts` — counts, singular/plural, failures, all-failed (no wall-clock), zero-settled → null, pending excluded, rounding.
- `components/TraceHeader.test.tsx` — skeleton pre-definition, real header post-definition, summary slot.
- `lib/streamReducer.test.ts` — `toPartialResult` fallbacks/overrides.
- `app/word/import-graph.test.ts` — unchanged; new files are types + presentational only (no research/llm modules in the `/word` server graph).

Gates: `bun test` / `lint` / `typecheck` / `build`. End-to-end Playwright verification (header no-jump measurement across sources/synthesis/done, chips→summary collapse, reduced-motion, aria-live) is being run against a prod build.

**Merge order:** independent; client-only UI polish, mergeable whenever green.

https://claude.ai/code/session_012GTdDDmz56DHGedvS2suof