### PR TITLE
refactor: drop defensive optional chaining on ancestryGraph.branches

### DIFF
--- a/components/StreamingEtymologyCard.tsx
+++ b/components/StreamingEtymologyCard.tsx
@@ -44,7 +44,7 @@ export function StreamingEtymologyCard({
 
   return (
     <div className="relative animate-fadeIn">
-      {sections.ancestryGraph && sections.ancestryGraph.branches?.length > 0 ? (
+      {sections.ancestryGraph && sections.ancestryGraph.branches.length > 0 ? (
         <AncestrySection graph={sections.ancestryGraph} word={resolvedWord} />
       ) : (
         <AncestrySkeleton />


### PR DESCRIPTION
Follow-up to #76 addressing the Gemini review comment on `components/StreamingEtymologyCard.tsx`.

`branches` is a **required** property of `AncestryGraph` (`lib/types.ts`: `branches: AncestryBranch[]`). Once the `sections.ancestryGraph &&` guard narrows `ancestryGraph` to a defined value, `branches` is guaranteed by the type contract, so the `?.` was defensive optional chaining on a required property — the exact pattern the repo's standards discourage (it weakens the contract and can mask schema bugs). It was carried over verbatim from the pre-refactor code.

Change: `sections.ancestryGraph.branches?.length` → `sections.ancestryGraph.branches.length`. Behavior is unchanged — the `sections.ancestryGraph &&` guard still gates rendering, and under strict json_schema streaming a closed `ancestryGraph` section always includes `branches`.

## Gates
- `bunx tsc --noEmit`: clean
- `bun run lint`: clean
- `bun test` (components + affected lib): 43 pass / 0 fail
- `bun run build`: succeeds

## Merge order
Independent; trivial type-contract cleanup, mergeable whenever green.

https://claude.ai/code/session_012GTdDDmz56DHGedvS2suof