### PR TITLE
Switch LLM requests to Luna and relax word admission

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -12,7 +12,7 @@ Users search for a word, and the app:
 2. Pre-parses etymological chains from source text (CPU-only)
 3. Uses OpenRouter to extract root morphemes from the first-pass source bundle
 4. Expands breadth with a bounded second pass over root pages and high-signal related pages from Etymonline and Wiktionary
-5. Sends the enriched research bundle to OpenRouter's Responses API using `openai/gpt-5.4-mini` for structured synthesis
+5. Sends the enriched research bundle to OpenRouter's Responses API using `openai/gpt-5.6-luna` for structured synthesis
 6. Post-processes LLM output to match ancestry stages to parsed evidence and assign programmatic confidence scores
 
 **Live**: https://etymex.com
@@ -50,8 +50,8 @@ GET /api/etymology?word=X[&stream=true]   (maxDuration 300s)
     ├── Singleflight lock (lib/singleflight.ts, owner-token lock; Redis down → 503 for uncached)
     ├── Agentic Research Pipeline (lib/research.ts; request.signal aborts in-flight work):
     │   ├── Phase 1: Fire all 6 source fetches at once (3 core + 3 optional);
-    │   │           only etymonline + wiktionary gate the next phase, the rest
-    │   │           join before synthesis. Raw etymonline/wiktionary pages come
+    │   │           only etymonline + wiktionary gate root expansion, while
+    │   │           Free Dictionary/Wikipedia can still admit synthesis. Raw pages come
     │   │           from a 7d Redis source cache when available (lib/sourceCache.ts)
     │   ├── Phase 1.5: Pre-parse "from X, from Y" chains (lib/etymologyParser.ts, CPU-only)
     │   ├── Phase 2: CPU root extraction (derivation formulas + chain affixes);
@@ -81,7 +81,7 @@ The app operates in **public mode** with server-side cost controls (added in PR 
 
 - **`lib/config.ts`** - Centralized configuration:
   - Per-IP rate caps: etymology 20/min + 200/day, pronunciation 20/min, general 60/min
-  - USD monthly limit: $10/month (`openai/gpt-5.4-mini` pricing in `costTracking` as fallback; OpenRouter-reported cost preferred)
+  - USD monthly limit: $10/month (`openai/gpt-5.6-luna` pricing in `costTracking` as fallback; OpenRouter-reported cost preferred)
   - Timeouts: source fetches 5s, synthesis LLM 90s, root-extraction LLM 15s, TTS 15s
   - Tiered prompt character budgets (`promptBudget`: main 1500 / supplemental 800 / root 700 / related 450)
   - Rate limits, singleflight settings, feature flags
@@ -100,7 +100,7 @@ The app operates in **public mode** with server-side cost controls (added in PR 
 - **`lib/cache.ts`** - Redis caching (via the shared `getRedis()` factory):
   - Etymology results: 30 day TTL, versioned keys (`etymology:v2.2:`)
   - TTS audio: 1 year TTL
-  - Negative cache: 6 hour TTL for admitted types (`no_sources`, `invalid_word`)
+  - Negative cache: 30 minute TTL for admitted types (`no_sources`, `invalid_word`)
   - Zod validation on reads only (writes are pre-validated by `finalizeResult` in lib/llm.ts)
 
 - **`lib/sourceCache.ts`** - 7-day Redis cache for raw etymonline/wiktionary page data (`src:v1:<source>:<word>`). Fail-open: no Redis or a Redis error means a live fetch. Saves repeated scrapes across result-cache misses and overlapping root/related lookups.
@@ -209,7 +209,7 @@ and the output is guaranteed-shape JSON.
 - Rate limit counters (per-IP, sliding windows)
 - Monthly spend counters (atomic accumulation) + operational counters (cache_hit/miss/error)
 - Singleflight owner-token locks (90s TTL, heartbeat-extended while work runs)
-- Negative cache for admitted invalid/no-source words (6hr TTL)
+- Negative cache for admitted invalid/no-source words (30m TTL)
 
 **Client-side** (localStorage):
 
@@ -295,7 +295,7 @@ All return `{ success: boolean, data?: T, error?: string }` wrapper.
 **Core Pipeline:**
 
 - `lib/research.ts` - Agentic research orchestrator (6-source parallel fetch)
-- `lib/llm.ts` - LLM client (OpenRouter Responses API for `openai/gpt-5.4-mini`; unified streaming/unary synthesis)
+- `lib/llm.ts` - LLM client (OpenRouter Responses API for `openai/gpt-5.6-luna`; unified streaming/unary synthesis)
 - `lib/sectionScanner.ts` - Incremental scanner emitting each top-level JSON field as it closes (powers synthesis_section SSE events)
 - `lib/responseAdapter.ts` - SSE/JSON response adapter for the etymology route's early returns
 - `lib/prompts.ts` - System prompt for LLM synthesis (content/grounding rules; shape enforced by schema)

--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ Open [http://localhost:3000](http://localhost:3000) in your browser.
 ### Configuration
 
 The app runs in **public mode** using a server-side OpenRouter API key and the
-`openai/gpt-5.4-mini` model on OpenRouter's Responses API. All searches are
+`openai/gpt-5.6-luna` model on OpenRouter's Responses API. All searches are
 rate-limited and cost-budgeted with a monthly spend cap. Set the
 `OPENROUTER_API_KEY` environment variable to enable it.
 
@@ -98,7 +98,7 @@ For local load testing, set `RATE_LIMIT_ENABLED=false` in `.env.local` and resta
 - **Framework**: [Next.js 16.1](https://nextjs.org/) with App Router
 - **UI**: [React 19.2](https://react.dev/) + [Tailwind CSS v4](https://tailwindcss.com/)
 - **LLM**: [OpenRouter Responses API](https://openrouter.ai/docs/api/api-reference/responses/create-responses)
-  using `openai/gpt-5.4-mini` with structured outputs
+  using `openai/gpt-5.6-luna` with structured outputs
 - **Validation**: [Zod 4.x](https://zod.dev/) for schema validation
 - **Caching/Rate Limiting**: [@upstash/redis](https://upstash.com/) + [@upstash/ratelimit](https://github.com/upstash/ratelimit)
 - **Analytics**: [@vercel/analytics](https://vercel.com/analytics)
@@ -199,17 +199,17 @@ etymology-explorer/
 
 1. **Request Deduplication**: Singleflight owner-token locks (90s TTL, heartbeat-extended) ensure one pipeline run per word; waiters poll the cache for the holder's result, and streaming waiters can take over if the holder crashes
 2. **Rate Limiting**: Per-IP rate limiting (20 req/min + 200 req/day) via Upstash Redis
-3. **Cache Check**: Redis cache lookup with versioned keys (`etymology:v2.2:`), schema validation on read, and negative cache (6h) for known no-source/invalid words. Without Redis, uncached searches return 503 (fail closed)
+3. **Cache Check**: Redis cache lookup with versioned keys (`etymology:v2.2:`), schema validation on read, and negative cache (30m) for known no-source/invalid words. Without Redis, uncached searches return 503 (fail closed)
 4. **Grounded Etymology Pipeline**:
    - **Parser** (CPU-only): Extracts "from X, from Y" chains from raw source text
    - **Agentic Research**: Multi-phase research pipeline (aborts mid-flight if the client disconnects):
-     - Phase 1: Fire all 6 source fetches at once (Etymonline, Wiktionary, Free Dictionary, Wikipedia, Urban Dictionary, Incel Wiki); only Etymonline + Wiktionary gate the next phase — the rest join before synthesis. Raw Etymonline/Wiktionary pages are served from a 7-day Redis source cache when available
+     - Phase 1: Fire all 6 source fetches at once (Etymonline, Wiktionary, Free Dictionary, Wikipedia, Urban Dictionary, Incel Wiki); Etymonline + Wiktionary gate root expansion, while a Free Dictionary or Wikipedia hit can still admit synthesis when both primary sources miss. Raw Etymonline/Wiktionary pages are served from a 7-day Redis source cache when available
      - Phase 2: Root morphemes extracted on-CPU from derivation formulas ("From X + Y", "equivalent to X + Y") and parsed-chain affixes (e.g., "telephone" → ["tele", "phone"]); a quick LLM call (15s timeout, truncated input) runs only when the CPU pass finds nothing
      - Phase 3: One parallel wave fetches root pages (up to 4 roots, etymonline + wiktionary) and main-word related-term pages (etymonline only) within the 16-fetch budget
    - **LLM Synthesis**: Aggregated research context sent to LLM with structured output schema
    - **Enricher** (CPU): Post-processes LLM output, assigns confidence scores (high/medium/low) based on source evidence match
 5. **Guaranteed JSON**: Using constrained decoding, the LLM produces valid JSON matching the exact schema
-6. **Budget Enforcement**: Cost guard tracks monthly spend (OpenRouter-reported cost, with `openai/gpt-5.4-mini` pricing as fallback) against a $10/month cap and switches from normal to cache_only mode at 90% of budget; both the root-extraction and synthesis LLM calls are counted
+6. **Budget Enforcement**: Cost guard tracks monthly spend (OpenRouter-reported cost, with `openai/gpt-5.6-luna` pricing as fallback) against a $10/month cap and switches from normal to cache_only mode at 90% of budget; both the root-extraction and synthesis LLM calls are counted
 7. **Rich Display**: Etymology rendered with expandable roots, ancestry graph with confidence badges, POS tags, modern usage, related words, and source attribution (supplemental sources are only surfaced when significance checks pass)
 
 ### Architecture Diagram
@@ -290,5 +290,5 @@ MIT
 - Modern slang definitions from [Urban Dictionary](https://www.urbandictionary.com/)
 - Supplemental community slang context from [Incel Wiki](https://incels.wiki/)
 - Pronunciation audio from [ElevenLabs](https://elevenlabs.io/)
-- Powered by [OpenRouter](https://openrouter.ai/) `openai/gpt-5.4-mini`
+- Powered by [OpenRouter](https://openrouter.ai/) `openai/gpt-5.6-luna`
 - Rate limiting and caching by [Upstash](https://upstash.com/)

--- a/app/api/etymology/route.ts
+++ b/app/api/etymology/route.ts
@@ -1,7 +1,7 @@
 import { NextRequest } from 'next/server'
 import { EtymologyResult, StreamEvent, StageConfidence, ResearchContext } from '@/lib/types'
 import { synthesizeFromResearch, getLlmUsageFromError, SynthesisResult } from '@/lib/llm'
-import { conductAgenticResearch } from '@/lib/research'
+import { conductAgenticResearch, hasCredibleMainSource } from '@/lib/research'
 import { isLikelyTypo, getSuggestions } from '@/lib/spellcheck'
 import { getRandomWord } from '@/lib/wordlist'
 import { getQuirkyMessage } from '@/lib/prompts'
@@ -165,7 +165,7 @@ export async function GET(request: NextRequest) {
         onProgress
       )
 
-      if (!researchContext.mainWord.etymonline && !researchContext.mainWord.wiktionary) {
+      if (!hasCredibleMainSource(researchContext)) {
         // Awaited so the entry lands BEFORE the lock releases — waiters
         // poll the negative cache to learn this word has no sources.
         await cacheNegative(normalizedWord, 'no_sources')

--- a/docs/model-bakeoff-2026-07.md
+++ b/docs/model-bakeoff-2026-07.md
@@ -1,15 +1,158 @@
 # Synthesis Model Bakeoff - July 7, 2026
 
-> **July 18 follow-up:** Production synthesis now uses `openai/gpt-5.6-luna`
-> at low reasoning after a fresh 15-word run and identical-context paired
-> comparisons showed materially lower latency with acceptable cost. Root
-> extraction also uses Luna, with reasoning disabled. The July 7 results and
-> decision below are retained as the historical baseline.
+> **July 18 follow-up:** Production now uses `openai/gpt-5.6-luna` for both
+> synthesis and the root-extraction fallback. A fresh paired 15-word run showed
+> materially lower synthesis latency at a modest cost increase. The July 7
+> results and decision below are retained as the historical baseline.
 
 This note records the OpenRouter model reruns from branch `feat/model-bakeoff`,
 after PR #71 (`feat/structured-synthesis`) added strict Responses schema mode,
 model-specific reasoning profiles, and source clipping that preserves tail
 evidence.
+
+## July 18 Follow-up: Luna Re-evaluation
+
+### Candidate screen
+
+The follow-up focused on models that could plausibly replace GPT-5.4 Mini without
+changing the synthesis transport contract. A synthesis candidate must work
+through OpenRouter's Responses endpoint, advertise strict JSON Schema support
+for `provider.require_parameters = true`, and remain fast enough for an
+interactive public endpoint. Root extraction has a separate, lighter gate
+described below.
+
+- [`openai/gpt-5.6-luna`](https://openrouter.ai/openai/gpt-5.6-luna-20260709)
+  advertised `response_format` and `structured_outputs`, with list pricing of
+  $1/M input tokens and $6/M output tokens. It advanced to the full benchmark.
+- [`thinkingmachines/inkling`](https://openrouter.ai/thinkingmachines/inkling)
+  was also reviewed. Its $1/M input and $4.05/M output pricing was attractive,
+  but the OpenRouter model metadata on July 18 did not advertise
+  `response_format` or `structured_outputs`. Because strict schema support is a
+  hard synthesis gate, Inkling did not pass the metadata eligibility screen and
+  was not sent through the paid 15-word run. Its strict Responses compatibility
+  was not live-tested; reconsider it if its OpenRouter capabilities change.
+
+The screen intentionally did not treat a lower list price as sufficient. This
+pipeline depends on schema correctness, predictable latency, and evidence-aware
+output. A model that does not advertise the strict Responses capabilities is
+not eligible for a paid synthesis benchmark without a separate compatibility
+probe.
+
+### Follow-up method
+
+Two full-pipeline runs were started together against the fixed 15-word set:
+
+```bash
+bun scripts/benchmark.ts --label bench-2026-07-18-gpt54-control \
+  --model openai/gpt-5.4-mini
+bun scripts/benchmark.ts --label bench-2026-07-18-gpt56-luna \
+  --model openai/gpt-5.6-luna
+```
+
+Running the pair concurrently reduced time-of-day and upstream-service drift.
+Both used the same code, word set, schemas, prompt budgets, and low synthesis
+reasoning profile. The `--model` override applied only to synthesis, so the
+root-extraction fallback remained GPT-5.4 Mini during both benchmark runs.
+
+This is a paired full-pipeline comparison, not a frozen-prompt laboratory test.
+Each run fetched and expanded its own research context, so source latency,
+network variance, and nondeterministic root extraction can affect total latency,
+input tokens, and the evidence available to synthesis. Synthesis latency and
+schema validity are the strongest signals; small confidence differences should
+not be interpreted as a controlled model-quality score.
+
+### Follow-up results
+
+| model                 | valid | p50 total | p50 synth | total cost | cost/word | synth under 10s | confidence high/med/low/unscored | total tokens in/out |
+| --------------------- | ----: | --------: | --------: | ---------: | --------: | --------------: | -------------------------------- | ------------------- |
+| `openai/gpt-5.4-mini` | 15/15 |    11.26s |     9.57s |    $0.1281 |  $0.00854 |           10/15 | 22/23/13/28                      | 60371/18410         |
+| `openai/gpt-5.6-luna` | 15/15 |    10.10s |     6.29s |    $0.1564 |  $0.01043 |           14/15 | 11/29/19/26                      | 58665/14171         |
+
+Costs include OpenRouter-reported synthesis and root-extraction spend. Because
+the benchmark's root fallback still used GPT-5.4 Mini in both runs, the cost
+difference primarily reflects synthesis. The control reported $0.12465 for
+synthesis and $0.00347 for six extraction calls; the Luna run reported $0.15324
+for synthesis and $0.00315 for six GPT-5.4 Mini extraction calls.
+
+Relative to the control, Luna:
+
+- reduced p50 synthesis latency by 34.3 percent (9.57s to 6.29s);
+- reduced p50 end-to-end latency by 10.3 percent (11.26s to 10.10s);
+- produced the faster synthesis result for 13 of 15 words and the faster total
+  result for 11 of 15;
+- reduced total output tokens by 23.0 percent (18,410 to 14,171);
+- increased reported cost per attempted word by 22.1 percent ($0.00854 to
+  $0.01043); and
+- remained schema-valid for all 15 words, with zero ungrounded reconstructed
+  stages in both runs.
+
+Here, `valid` means the final post-processed result passed
+`EtymologyResultSchema`. The unary synthesis path can retry malformed output
+once, but this benchmark version did not record attempt or retry counts.
+Therefore, 15/15 is final schema validity, not evidence that every first model
+response passed without a retry.
+
+The confidence distribution moved away from `high` toward `medium` and `low`.
+That is a real caution signal, but confidence is assigned after synthesis by
+matching stages against the independently gathered source evidence; it is not a
+blinded human quality judgment. No separate blinded preference evaluation was
+recorded in this session, so the result supports an operational latency/cost
+decision rather than a claim that Luna is categorically better at etymology.
+
+### Root-extraction smoke test
+
+After changing the production default, the exact Luna root-extraction request
+was probed separately because the full benchmark had kept that call on GPT-5.4
+Mini. The probe used `bread` with the production prompt, strict root schema,
+100-token output cap, and `reasoning = { effort: "none" }`. It returned
+`{"roots":["bread"]}` in about 1.5 seconds at a reported cost of $0.000149.
+
+`provider.require_parameters` remains synthesis-only. Prior live testing showed
+that adding it to this tiny extraction request changed routing from roughly one
+second to 15 seconds or more, consuming the entire extraction timeout. The root
+request still asks for strict JSON Schema; application code then parses and
+normalizes a `roots` array, caps it at four entries, and safely returns no roots
+when output is unusable.
+
+This single call verifies route compatibility, valid shape, latency, and billing
+on one representative single-root input. It is not an extraction-quality or
+reliability benchmark. A stronger follow-up would compare Luna and GPT-5.4 Mini
+over single-root, multi-root, affix-heavy, no-source, malformed-output, and
+timeout cases.
+
+### July 18 decision and implementation
+
+Switch every application LLM request to `openai/gpt-5.6-luna`:
+
+- synthesis uses low reasoning;
+- root extraction uses no reasoning;
+- there is no application-level fallback to GPT-5.4 Mini or another model; and
+- the $1/M input and $6/M output values in `CONFIG.costTracking` are accounting
+  fallbacks only, used when OpenRouter omits `usage.cost`. They do not select a
+  fallback model.
+
+In this non-frozen full-pipeline run, the change cost roughly $0.0019 more per
+uncached benchmark word and coincided with a 3.28-second improvement in p50
+synthesis latency. The existing $10 monthly budget, cache-only threshold,
+30-day result cache, and singleflight request deduplication continue to bound
+the production impact.
+
+The three uses of “fallback” are distinct:
+
+| fallback type | current behavior                                                                       |
+| ------------- | -------------------------------------------------------------------------------------- |
+| model         | none; every LLM request names Luna                                                     |
+| algorithmic   | CPU root extraction runs first; Luna is called only when CPU extraction finds no roots |
+| accounting    | configured Luna prices estimate spend only when OpenRouter omits `usage.cost`          |
+
+The change is implemented in draft PR
+[#79](https://github.com/thepushkarp/etymology-explorer/pull/79) alongside the
+orthogonal valid-word admission fix. Verification for the combined change
+included 216 passing tests, a successful production build, ESLint with zero
+errors, changed-file Prettier validation, and the live Luna extraction smoke test
+above.
+
+## July 7 Historical Baseline
 
 ## Method
 
@@ -71,7 +214,7 @@ current production candidate.
 | `moonshotai/kimi-k2.6`     | first word produced no artifact before manual stop                              | stalled with reasoning disabled               |
 | `tencent/hy3`              | tiny strict-schema probe timed out after 70s                                    | unsuitable for Responses structured synthesis |
 
-## Decision
+## July 7 Decision (Historical)
 
 Keep `openai/gpt-5.4-mini` as the production synthesis model.
 
@@ -91,7 +234,7 @@ is the only untested speed lever, relevant only for a future non-interactive /
 background synthesis path where M3's ~4x lower cost and higher confidence would
 pay off.
 
-## Root Extraction Fallback Model
+## July 7 Root Extraction Position (Historical)
 
 The `--model` flag overrides the synthesis model only; the root extraction
 fallback (`extractRootsQuick` in `lib/research.ts`, request built by

--- a/docs/model-bakeoff-2026-07.md
+++ b/docs/model-bakeoff-2026-07.md
@@ -1,5 +1,11 @@
 # Synthesis Model Bakeoff - July 7, 2026
 
+> **July 18 follow-up:** Production synthesis now uses `openai/gpt-5.6-luna`
+> at low reasoning after a fresh 15-word run and identical-context paired
+> comparisons showed materially lower latency with acceptable cost. Root
+> extraction also uses Luna, with reasoning disabled. The July 7 results and
+> decision below are retained as the historical baseline.
+
 This note records the OpenRouter model reruns from branch `feat/model-bakeoff`,
 after PR #71 (`feat/structured-synthesis`) added strict Responses schema mode,
 model-specific reasoning profiles, and source clipping that preserves tail

--- a/lib/cache.ts
+++ b/lib/cache.ts
@@ -149,14 +149,14 @@ export async function cacheAudio(word: string, audioBase64: string): Promise<voi
 }
 
 /**
- * Check if a word is in the negative cache (known bad/gibberish words).
+ * Check if a word is in the negative cache (known invalid/no-source words).
  * Returns false on error (fail open).
  */
 export async function getNegativeCache(word: string): Promise<boolean> {
   const redis = getRedis()
   if (!redis) return false
 
-  const key = `neg:v1:${word.toLowerCase().trim()}`
+  const key = `neg:v2:${word.toLowerCase().trim()}`
   try {
     const exists = await redis.exists(key)
     return exists === 1
@@ -167,7 +167,7 @@ export async function getNegativeCache(word: string): Promise<boolean> {
 }
 
 /**
- * Mark a word in the negative cache to prevent repeated fetches for gibberish.
+ * Mark a word in the negative cache to prevent repeated no-source fetches.
  * Only caches specific error types — transient errors should NOT be cached.
  * Fails silently.
  */
@@ -179,7 +179,7 @@ export async function cacheNegative(word: string, errorType: string): Promise<vo
     return
   }
 
-  const key = `neg:v1:${word.toLowerCase().trim()}`
+  const key = `neg:v2:${word.toLowerCase().trim()}`
   try {
     await redis.set(key, '1', { ex: jitterTTL(CONFIG.negativeCacheTTL) })
   } catch (error) {

--- a/lib/config.ts
+++ b/lib/config.ts
@@ -5,7 +5,7 @@
 
 export const CONFIG = {
   // LLM
-  model: 'openai/gpt-5.4-mini',
+  model: 'openai/gpt-5.6-luna',
   synthesisMaxTokens: 9000,
   rootExtractionMaxTokens: 100,
 
@@ -43,7 +43,7 @@ export const CONFIG = {
   // Cache TTLs (seconds)
   etymologyCacheTTL: 30 * 24 * 60 * 60, // 30 days
   audioCacheTTL: 365 * 24 * 60 * 60, // 1 year
-  negativeCacheTTL: 6 * 60 * 60, // 6 hours — prevents repeated fetches for gibberish
+  negativeCacheTTL: 30 * 60, // 30m — limits repeat misses without cementing transient source failures
   sourceCacheTTL: 7 * 24 * 60 * 60, // 7 days — raw etymonline/wiktionary page data
 
   // Timeouts (milliseconds)
@@ -66,7 +66,7 @@ export const CONFIG = {
 
   // USD-based cost tracking
   costTracking: {
-    pricingPerMillionTokens: { input: 0.75, output: 4.5 }, // fallback when OpenRouter omits cost
+    pricingPerMillionTokens: { input: 1, output: 6 }, // Luna fallback when OpenRouter omits cost
     monthlyLimitUSD: 10.0,
     cacheOnlyAtPercent: 0.9, // serve only cached results at 90% of budget
   },

--- a/lib/openrouterResponses.test.ts
+++ b/lib/openrouterResponses.test.ts
@@ -11,7 +11,7 @@ describe('openrouterResponses', () => {
   test('buildSynthesisRequest uses strict json_schema mode with low reasoning', () => {
     const request = buildSynthesisRequest('Analyze this word')
 
-    expect(request.model).toBe('openai/gpt-5.4-mini')
+    expect(request.model).toBe('openai/gpt-5.6-luna')
     expect(request.reasoning).toEqual({ effort: 'low' })
     expect(request.max_output_tokens).toBe(9000)
     expect(request.text.format).toMatchObject({
@@ -25,6 +25,9 @@ describe('openrouterResponses', () => {
   })
 
   test('buildSynthesisRequest adapts reasoning to model capabilities', () => {
+    expect(buildSynthesisRequest('Analyze', 'openai/gpt-5.6-luna').reasoning).toEqual({
+      effort: 'low',
+    })
     expect(buildSynthesisRequest('Analyze', 'google/gemini-3.5-flash').reasoning).toEqual({
       effort: 'minimal',
       exclude: true,
@@ -57,7 +60,7 @@ describe('openrouterResponses', () => {
   test('buildRootExtractionRequest disables reasoning for tiny root extraction output', () => {
     const request = buildRootExtractionRequest('Analyze roots')
 
-    expect(request.model).toBe('openai/gpt-5.4-mini')
+    expect(request.model).toBe('openai/gpt-5.6-luna')
     expect(request.reasoning).toEqual({ effort: 'none' })
     // require_parameters is synthesis-only: adding it here slow-routed the
     // ~100-token extraction call from ~1s to 15s+ in live tests.

--- a/lib/openrouterResponses.ts
+++ b/lib/openrouterResponses.ts
@@ -97,8 +97,8 @@ type OpenRouterStreamEvent = {
 const OPENROUTER_RESPONSES_URL = 'https://openrouter.ai/api/v1/responses'
 
 const SYNTHESIS_REASONING_BY_MODEL: Record<string, ReasoningConfig | undefined> = {
-  // Production baseline: keep the existing low-effort synthesis behavior.
-  'openai/gpt-5.4-mini': { effort: 'low' },
+  // Production models use low-effort synthesis to balance grounding and latency.
+  'openai/gpt-5.6-luna': { effort: 'low' },
   // Gemini 3.5 Flash rejects disabled/none reasoning; minimal is the cheapest
   // valid setting per /api/v1/models and live probe.
   'google/gemini-3.5-flash': { effort: 'minimal', exclude: true },

--- a/lib/research.test.ts
+++ b/lib/research.test.ts
@@ -5,6 +5,7 @@ import {
   extractRootsQuick,
   extractRelatedTerms,
   extractRootsCpu,
+  hasCredibleMainSource,
 } from '@/lib/research'
 import { extractEtymonlineRelatedEntries, fetchEtymonline } from '@/lib/etymonline'
 import { parseSourceTexts } from '@/lib/etymologyParser'
@@ -128,6 +129,39 @@ describe('extractRootsCpu', () => {
 })
 
 describe('research breadth', () => {
+  test('admits credible supplemental sources when primary etymology sources miss', () => {
+    const context: ResearchContext = {
+      mainWord: {
+        word: 'validword',
+        etymonline: null,
+        wiktionary: null,
+        freeDictionary: null,
+        wikipedia: null,
+        urbanDictionary: null,
+        incelsWiki: null,
+      },
+      identifiedRoots: [],
+      rootResearch: [],
+      relatedResearch: [],
+      totalSourcesFetched: 6,
+    }
+
+    expect(hasCredibleMainSource(context)).toBe(false)
+
+    context.mainWord.wikipedia = {
+      text: 'A documented English word.',
+      url: 'https://en.wikipedia.org/wiki/Validword',
+    }
+    expect(hasCredibleMainSource(context)).toBe(true)
+
+    context.mainWord.wikipedia = null
+    context.mainWord.urbanDictionary = {
+      text: 'Community slang definition only.',
+      url: 'https://www.urbandictionary.com/define.php?term=validword',
+    }
+    expect(hasCredibleMainSource(context)).toBe(false)
+  })
+
   test('extractEtymonlineRelatedEntries finds linked relation entries from escaped page payloads', () => {
     const html = String.raw`{\"word\":\"contradict\",\"desc\":\"assert the contrary\"},{\"word\":\"contra\",\"desc\":\"Latin preposition meaning against\"},{\"word\":\"*deik-\",\"desc\":\"PIE root meaning to show\"},{\"key\":\"syn_ant\",\"word\":\"contravene\",\"desc\":\"from Latin contra + venire\"},{\"word\":\"gainsay\",\"desc\":\"literally say against\"},{\"word\":\"contradictory\"}`
 

--- a/lib/research.ts
+++ b/lib/research.ts
@@ -36,6 +36,19 @@ export interface RootExtraction {
   usage: LlmUsage | null // null when no LLM call was made (or it failed before billing)
 }
 
+/**
+ * Decide whether the main-word bundle has enough independent evidence to
+ * justify synthesis. Curated dictionary/encyclopedia hits can confirm a real
+ * word when the two etymology-specific sources miss or are temporarily down;
+ * community-only sources are not sufficient on their own.
+ */
+export function hasCredibleMainSource(context: ResearchContext): boolean {
+  const { mainWord } = context
+  return Boolean(
+    mainWord.etymonline || mainWord.wiktionary || mainWord.freeDictionary || mainWord.wikipedia
+  )
+}
+
 export async function extractRootsQuick(
   word: string,
   etymonlineText: string | null,


### PR DESCRIPTION
## Summary

- switch synthesis and root-extraction OpenRouter requests to `openai/gpt-5.6-luna`
- keep low reasoning for synthesis and disable reasoning for the small root-extraction fallback
- update fallback cost accounting and model documentation for Luna pricing
- admit searches backed by Free Dictionary or Wikipedia when Etymonline and Wiktionary miss
- shorten and version negative caching so false invalid-word results do not linger

## Why

The Luna bakeoff showed materially lower synthesis latency at acceptable cost. Separately, valid words were classified as nonsense whenever both primary etymology sources returned null, including transient failures, even when curated supplemental sources confirmed the word.

## Impact

New uncached searches use Luna for every LLM request. Valid words with curated dictionary or encyclopedia evidence can proceed without primary-source hits. Community-only sources remain insufficient. Old `neg:v1` entries are ignored, and new no-source entries expire after 30 minutes.

## Validation

- `bun test` — 216 passed
- `bun run lint` — zero errors; one pre-existing warning in `.remember/tmp/last-ndc.ts`
- changed-file Prettier check
- `bun run build`
- live Luna strict root-extraction probe